### PR TITLE
fixes incorrect button text in message service of MahApps

### DIFF
--- a/src/Examples/Orchestra.Examples.MahApps/Orchestra.Examples.MahApps.Shared/ViewModels/PersonsViewModel.cs
+++ b/src/Examples/Orchestra.Examples.MahApps/Orchestra.Examples.MahApps.Shared/ViewModels/PersonsViewModel.cs
@@ -97,7 +97,7 @@ namespace Orchestra.Examples.MahApps.ViewModels
         {
             var selectedPerson = SelectedPerson;
 
-            if (await _messageService.ShowAsync(string.Format("Are you sure you want to remove person '{0}'?", selectedPerson), "Are you sure?", MessageButton.YesNo, MessageImage.Question) == MessageResult.Yes)
+            if (await _messageService.ShowAsync(string.Format("Are you sure you want to remove person '{0}'?", selectedPerson), "Are you sure?", MessageButton.YesNoCancel, MessageImage.Question) == MessageResult.Yes)
             {
                 Log.Info("Removing person '{0}'", selectedPerson);
 

--- a/src/Orchestra.Core/Orchestra.Core/Orchestra.Core.Shared/Converters/MessageButtonToCollapsingVisibilityConverter.cs
+++ b/src/Orchestra.Core/Orchestra.Core/Orchestra.Core.Shared/Converters/MessageButtonToCollapsingVisibilityConverter.cs
@@ -9,13 +9,12 @@ namespace Orchestra.Converters
 {
     using System;
     using System.Windows;
-    using Catel.Data;
     using Catel.MVVM.Converters;
     using Catel.Services;
 
     internal class MessageButtonToCollapsingVisibilityConverter : VisibilityConverterBase
     {
-        public MessageButtonToCollapsingVisibilityConverter() 
+        public MessageButtonToCollapsingVisibilityConverter()
             : base(Visibility.Collapsed)
         {
         }

--- a/src/Orchestra.Core/Orchestra.Core/Orchestra.Core.Shared/Services/MessageService.cs
+++ b/src/Orchestra.Core/Orchestra.Core/Orchestra.Core.Shared/Services/MessageService.cs
@@ -7,7 +7,6 @@
 
 namespace Orchestra.Services
 {
-    using System;
     using System.Threading.Tasks;
     using System.Windows.Input;
     using Catel;

--- a/src/Orchestra.Core/Orchestra.Core/Orchestra.Core.Shared/Views/MessageBoxWindow.xaml
+++ b/src/Orchestra.Core/Orchestra.Core/Orchestra.Core.Shared/Views/MessageBoxWindow.xaml
@@ -6,12 +6,12 @@
                   xmlns:i="http://schemas.microsoft.com/expression/2010/interactivity"
                   SizeToContent="WidthAndHeight" ResizeMode="NoResize"
                   WindowStartupLocation="CenterOwner" CanCloseUsingEscape="False">
-    
+
     <i:Interaction.Behaviors>
         <catel:KeyPressToCommand Command="{Binding EscapeCommand}" Key="Escape" />
         <catel:KeyPressToCommand Command="{Binding CopyToClipboard}" Key="C" Modifiers="Control" />
     </i:Interaction.Behaviors>
-    
+
     <Grid Margin="10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" MinHeight="90" />
@@ -28,7 +28,7 @@
                 <ScrollViewer DockPanel.Dock="Top" MaxHeight="400" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Hidden" >
                     <TextBlock TextWrapping="Wrap" MaxWidth="360" HorizontalAlignment="Stretch" Margin="0 0 0 10" Text="{Binding Message}"/>
                 </ScrollViewer>
-                
+
                 <StackPanel Orientation="Horizontal" Margin="0 10 0 0" HorizontalAlignment="Right" VerticalAlignment="Bottom">
                     <Button Content="{catel:LanguageBinding OK}" Command="{Binding OkCommand}" Width="80" Margin="6 2 0 2"
                             Visibility="{Binding Button, Converter={converters:MessageButtonToCollapsingVisibilityConverter}, ConverterParameter=OK}" />

--- a/src/Orchestra.Core/Orchestra.Core/Orchestra.Core.Shared/Views/MessageBoxWindow.xaml.cs
+++ b/src/Orchestra.Core/Orchestra.Core/Orchestra.Core.Shared/Views/MessageBoxWindow.xaml.cs
@@ -7,7 +7,6 @@
 
 namespace Orchestra.Views
 {
-    using System;
     using Catel.Services;
     using Catel.Windows;
     using ViewModels;

--- a/src/Orchestra.Shell/Orchestra.Shell.MahApps/Orchestra.Shell.MahApps.Shared/Services/MahAppsMessageService.cs
+++ b/src/Orchestra.Shell/Orchestra.Shell.MahApps/Orchestra.Shell.MahApps.Shared/Services/MahAppsMessageService.cs
@@ -10,7 +10,7 @@ namespace Orchestra.Services
     using System;
     using System.Threading.Tasks;
     using System.Windows;
-    using Catel.IoC;
+    using Catel;
     using Catel.Services;
     using MahApps.Metro.Controls;
     using MahApps.Metro.Controls.Dialogs;
@@ -18,11 +18,15 @@ namespace Orchestra.Services
     public class MahAppsMessageService : Catel.Services.MessageService
     {
         private readonly IDispatcherService _dispatcherService;
+        private readonly ILanguageService _languageService;
 
-        public MahAppsMessageService(IDispatcherService dispatcherService)
+        public MahAppsMessageService(IDispatcherService dispatcherService, ILanguageService languageService)
             : base(dispatcherService)
         {
+            Argument.IsNotNull(() => languageService);
+
             _dispatcherService = dispatcherService;
+            _languageService = languageService;
         }
 
         protected override Task<MessageResult> ShowMessageBoxAsync(string message, string caption = "", MessageButton button = MessageButton.OK, MessageImage icon = MessageImage.None)
@@ -32,7 +36,6 @@ namespace Orchestra.Services
             var negativeResult = MessageResult.No;
             var auxiliaryResult = MessageResult.Cancel;
 
-            var languageService = ServiceLocator.Default.ResolveType<ILanguageService>();
             MetroDialogSettings settings = new MetroDialogSettings();
 
             switch (button)
@@ -40,23 +43,23 @@ namespace Orchestra.Services
                 case MessageButton.OK:
                     style = MessageDialogStyle.Affirmative;
                     affirmativeResult = MessageResult.OK;
-                    settings.AffirmativeButtonText = languageService.GetString("OK");
+                    settings.AffirmativeButtonText = _languageService.GetString("OK");
                     break;
 
                 case MessageButton.OKCancel:
                     style = MessageDialogStyle.AffirmativeAndNegative;
                     affirmativeResult = MessageResult.OK;
                     negativeResult = MessageResult.Cancel;
-                    settings.AffirmativeButtonText = languageService.GetString("OK");
-                    settings.NegativeButtonText = languageService.GetString("Cancel");
+                    settings.AffirmativeButtonText = _languageService.GetString("OK");
+                    settings.NegativeButtonText = _languageService.GetString("Cancel");
                     break;
 
                 case MessageButton.YesNo:
                     style = MessageDialogStyle.AffirmativeAndNegative;
                     affirmativeResult = MessageResult.Yes;
                     negativeResult = MessageResult.No;
-                    settings.AffirmativeButtonText = languageService.GetString("Yes");
-                    settings.NegativeButtonText = languageService.GetString("No");
+                    settings.AffirmativeButtonText = _languageService.GetString("Yes");
+                    settings.NegativeButtonText = _languageService.GetString("No");
                     break;
 
                 case MessageButton.YesNoCancel:
@@ -64,9 +67,9 @@ namespace Orchestra.Services
                     affirmativeResult = MessageResult.Yes;
                     negativeResult = MessageResult.No;
                     auxiliaryResult = MessageResult.Cancel;
-                    settings.AffirmativeButtonText = languageService.GetString("Yes");
-                    settings.NegativeButtonText = languageService.GetString("No");
-                    settings.FirstAuxiliaryButtonText = languageService.GetString("Cancel");
+                    settings.AffirmativeButtonText = _languageService.GetString("Yes");
+                    settings.NegativeButtonText = _languageService.GetString("No");
+                    settings.FirstAuxiliaryButtonText = _languageService.GetString("Cancel");
                     break;
 
                 default:

--- a/src/Orchestra.Shell/Orchestra.Shell.MahApps/Orchestra.Shell.MahApps.Shared/Services/MahAppsMessageService.cs
+++ b/src/Orchestra.Shell/Orchestra.Shell.MahApps/Orchestra.Shell.MahApps.Shared/Services/MahAppsMessageService.cs
@@ -10,8 +10,8 @@ namespace Orchestra.Services
     using System;
     using System.Threading.Tasks;
     using System.Windows;
+    using Catel.IoC;
     using Catel.Services;
-    using Catel.Threading;
     using MahApps.Metro.Controls;
     using MahApps.Metro.Controls.Dialogs;
 
@@ -32,23 +32,31 @@ namespace Orchestra.Services
             var negativeResult = MessageResult.No;
             var auxiliaryResult = MessageResult.Cancel;
 
+            var languageService = ServiceLocator.Default.ResolveType<ILanguageService>();
+            MetroDialogSettings settings = new MetroDialogSettings();
+
             switch (button)
             {
                 case MessageButton.OK:
                     style = MessageDialogStyle.Affirmative;
                     affirmativeResult = MessageResult.OK;
+                    settings.AffirmativeButtonText = languageService.GetString("OK");
                     break;
 
                 case MessageButton.OKCancel:
                     style = MessageDialogStyle.AffirmativeAndNegative;
                     affirmativeResult = MessageResult.OK;
                     negativeResult = MessageResult.Cancel;
+                    settings.AffirmativeButtonText = languageService.GetString("OK");
+                    settings.NegativeButtonText = languageService.GetString("Cancel");
                     break;
 
                 case MessageButton.YesNo:
                     style = MessageDialogStyle.AffirmativeAndNegative;
                     affirmativeResult = MessageResult.Yes;
                     negativeResult = MessageResult.No;
+                    settings.AffirmativeButtonText = languageService.GetString("Yes");
+                    settings.NegativeButtonText = languageService.GetString("No");
                     break;
 
                 case MessageButton.YesNoCancel:
@@ -56,6 +64,9 @@ namespace Orchestra.Services
                     affirmativeResult = MessageResult.Yes;
                     negativeResult = MessageResult.No;
                     auxiliaryResult = MessageResult.Cancel;
+                    settings.AffirmativeButtonText = languageService.GetString("Yes");
+                    settings.NegativeButtonText = languageService.GetString("No");
+                    settings.FirstAuxiliaryButtonText = languageService.GetString("Cancel");
                     break;
 
                 default:
@@ -75,7 +86,7 @@ namespace Orchestra.Services
                     return;
                 }
 
-                var result = await window.ShowMessageAsync(caption, message, style);
+                var result = await window.ShowMessageAsync(caption, message, style, settings);
                 switch (result)
                 {
                     case MessageDialogResult.Negative:


### PR DESCRIPTION
Fixes #56.

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- uses correct button text
- respects i18n

