### PR TITLE
(x) #ORCOMP-307 Applications automatically clean up their own log files (No more than 10 log files and 10 crash reports and no logs older than 1 week)

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -13,3 +13,4 @@
 Geert van Horrik <geert@catenalogic.com>
 Maksim Khomutov <mkhomutov@gmail.com>
 Manuel Pfemeter <manuel.pfemeter@gmx.de>
+Igr Alexánder Fernández Saúco <alexander.fernandez.sauco@gmail.com>

--- a/src/Orchestra.Core/Orchestra.Core/Orchestra.Core.Shared/Helpers/LogHelper.cs
+++ b/src/Orchestra.Core/Orchestra.Core/Orchestra.Core.Shared/Helpers/LogHelper.cs
@@ -9,10 +9,33 @@ namespace Orchestra
 {
     using System;
     using System.IO;
-    using System.Threading.Tasks;
+    using System.Linq;
     using Catel;
     using Catel.Logging;
     using Path = Catel.IO.Path;
+
+    public static class LogFilePrefixes
+    {
+        /// <summary>
+        /// The crashreport prefix.
+        /// </summary>
+        public static readonly string Crashreport = "Crashreport";
+
+        /// <summary>
+        /// The entry assembly name prefix.
+        /// </summary>
+        public static readonly string EntryAssemblyName = AssemblyHelper.GetEntryAssembly().GetName().Name;
+
+        /// <summary>
+        /// The 'Log' file log prefix.
+        /// </summary>
+        public static readonly string Log = "Log";
+
+        /// <summary>
+        /// All file log prefixes
+        /// </summary>
+        public static readonly string[] All = { EntryAssemblyName, Crashreport, Log };
+    }
 
     /// <summary>
     /// Helper class for logging.
@@ -26,7 +49,7 @@ namespace Orchestra
         /// </summary>
         public static void AddFileLogListener()
         {
-            AddFileLogListener("Log");
+            AddFileLogListener(LogFilePrefixes.Log);
         }
 
         /// <summary>
@@ -35,7 +58,7 @@ namespace Orchestra
         /// <param name="ex">The unhandled exception.</param>
         public static void AddLogListenerForUnhandledException(Exception ex)
         {
-            AddFileLogListener("Crashreport");
+            AddFileLogListener(LogFilePrefixes.Crashreport);
 
             Log.Error(ex, "Application crashed");
 
@@ -58,6 +81,20 @@ namespace Orchestra
             return fileLogListener;
         }
 
+        public static void CleanUpAllLogTypeFiles(bool keepCleanInRealTime = false)
+        {
+            var directory = Path.Combine(Path.GetApplicationDataDirectory(), "log");
+            foreach (var prefix in LogFilePrefixes.All)
+            {
+                var filter = prefix + "*.log";
+                CleanUpLogFiles(directory, filter);
+                if (keepCleanInRealTime)
+                {
+                    ConfigureFileSystemWatcher(directory, filter);
+                }
+            }
+        }
+
         private static void AddFileLogListener(string prefix)
         {
             var fileLogListener = CreateFileLogListener(prefix);
@@ -66,6 +103,36 @@ namespace Orchestra
 
             Log.LogProductInfo();
             Log.LogDeviceInfo();
+        }
+
+        private static void ConfigureFileSystemWatcher(string directory, string filter)
+        {
+            var fileSystemWatcher = new FileSystemWatcher(directory, filter)
+            {
+                EnableRaisingEvents = true
+            };
+
+            fileSystemWatcher.Created += (sender, args) => { CleanUpLogFiles(directory, filter); };
+        }
+
+        private static void CleanUpLogFiles(string directory, string filter)
+        {
+            try
+            {
+                var files = Directory.GetFiles(directory, filter).Select(file => new { FileName = file, LastWriteTime = File.GetLastWriteTime(file)} ).ToList();
+
+                files.Sort((f1, f2) => f1.LastWriteTime.CompareTo(f2.LastWriteTime));
+
+                int i = 0;
+                while (i < files.Count && (files[i].LastWriteTime < DateTime.Now.AddDays(-7) || files.Count - i > 10))
+                {
+                    File.Delete(files[i].FileName);
+                    i++;
+                }
+            }
+            catch (Exception)
+            {
+            }
         }
     }
 }

--- a/src/Orchestra.Core/Orchestra.Core/Orchestra.Core.Shared/ModuleInitializer.cs
+++ b/src/Orchestra.Core/Orchestra.Core/Orchestra.Core.Shared/ModuleInitializer.cs
@@ -101,29 +101,9 @@ public static class ModuleInitializer
 
     private static void InitializeLogging()
     {
-        // Delete all log files older than 1 week
-        try
-        {
-            var applicationDataDirectory = Catel.IO.Path.GetApplicationDataDirectory();
-            if (Directory.Exists(applicationDataDirectory))
-            {
-                var logFiles = Directory.GetFiles(applicationDataDirectory, "*.log");
-                foreach (var logFile in logFiles)
-                {
-                    var lastWriteTime = File.GetLastWriteTime(logFile);
-                    if (lastWriteTime < DateTime.Now.AddDays(-7))
-                    {
-                        File.Delete(logFile);
-                    }
-                }
-            }
-        }
-        catch (Exception)
-        {
-            // Ignore
-        }
+        LogHelper.CleanUpAllLogTypeFiles();
 
-        var fileLogListener = LogHelper.CreateFileLogListener(AssemblyHelper.GetEntryAssembly().GetName().Name);
+        var fileLogListener = LogHelper.CreateFileLogListener(LogFilePrefixes.EntryAssemblyName);
 
         fileLogListener.IsDebugEnabled = false;
         fileLogListener.IsInfoEnabled = true;


### PR DESCRIPTION
Fixes  #ORCOMP-307.

### Changes proposed in this pull request:

- Applications automatically clean up their own log files (No more than 10 log files and 10 crash reports and no logs older than 1 week)