### PR TITLE
(*) #ORCOMP-348 Log keyboard mappings not found as debug instead of warning

### DIFF
--- a/src/Orchestra.Core/Orchestra.Core/Orchestra.Core.Shared/Services/KeyboardMappingsService.cs
+++ b/src/Orchestra.Core/Orchestra.Core/Orchestra.Core.Shared/Services/KeyboardMappingsService.cs
@@ -67,7 +67,7 @@ namespace Orchestra.Services
 
                             if (!_commandManager.IsCommandCreated(keyboardMapping.CommandName))
                             {
-                                Log.Warning("Command '{0}' is not created in the CommandManager, cannot update input gesture", keyboardMapping.CommandName);
+                                Log.Debug("Command '{0}' is not created in the CommandManager, cannot update input gesture", keyboardMapping.CommandName);
                                 continue;
                             }
 


### PR DESCRIPTION
Fixes #ORCOMP-348.

### Changes proposed in this pull request:

- Log keyboard mappings not found as debug instead of warning
