### PR TITLE
Translated Resources.ru.resx

### DIFF
--- a/src/Orchestra.Core/MultilingualResources/Orchestra.Core.ru.xlf
+++ b/src/Orchestra.Core/MultilingualResources/Orchestra.Core.ru.xlf
@@ -8,7 +8,7 @@
       <group id="ORCHESTRA.CORE/PROPERTIES/RESOURCES.RESX" datatype="resx">
         <trans-unit id="Orchestra_AllRightsReserved" translate="yes" xml:space="preserve">
           <source>All rights reserved</source>
-          <target state="translated">Все права сохранены</target>
+          <target state="translated">Все права защищены</target>
         </trans-unit>
         <trans-unit id="Orchestra_Assign" translate="yes" xml:space="preserve">
           <source>Assign</source>
@@ -84,7 +84,7 @@
         </trans-unit>
         <trans-unit id="Orchestra_NoLogListenerAvailable" translate="yes" xml:space="preserve">
           <source>No log listener available that can be opened. Please contact support.</source>
-          <target state="translated">Нет доступных для чтения логгеров. Пожалуйста, свяжитесь со службой технической поддержки.</target>
+          <target state="translated">Нет логгеров, которые можно было бы использовать. Пожалуйста, свяжитесь со службой технической поддержки.</target>
         </trans-unit>
         <trans-unit id="Orchestra_NotStartedCorrectly_01" translate="yes" xml:space="preserve">
           <source>It seems that the application failed to start correctly the last time it was started.</source>
@@ -100,7 +100,7 @@
         </trans-unit>
         <trans-unit id="Orchestra_PressShortcutKeys" translate="yes" xml:space="preserve">
           <source>Press shortcut keys:</source>
-          <target state="translated">Нажмите сочетание клавиш:</target>
+          <target state="translated">Используйте сочетание клавиш:</target>
         </trans-unit>
         <trans-unit id="Orchestra_Print" translate="yes" xml:space="preserve">
           <source>Print</source>

--- a/src/Orchestra.Core/MultilingualResources/Orchestra.Core.ru.xlf
+++ b/src/Orchestra.Core/MultilingualResources/Orchestra.Core.ru.xlf
@@ -8,198 +8,159 @@
       <group id="ORCHESTRA.CORE/PROPERTIES/RESOURCES.RESX" datatype="resx">
         <trans-unit id="Orchestra_AllRightsReserved" translate="yes" xml:space="preserve">
           <source>All rights reserved</source>
-          <target state="needs-review-translation">All rights reserved</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Все права сохранены</target>
         </trans-unit>
         <trans-unit id="Orchestra_Assign" translate="yes" xml:space="preserve">
           <source>Assign</source>
-          <target state="needs-review-translation">Assign</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Привязать</target>
         </trans-unit>
         <trans-unit id="Orchestra_AssignInputGestureAreYouSure" translate="yes" xml:space="preserve">
           <source>Are you sure you want to assign the input gesture to '{0}'. It will be removed from the other commands.</source>
-          <target state="needs-review-translation">Are you sure you want to assign the input gesture to '{0}'. It will be removed from the other commands.</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Вы уверены, что хотите привязать сочетание клавиш к '{0}'? Оно будет удалено для остальных команд.</target>
         </trans-unit>
         <trans-unit id="Orchestra_AssignInputGestureUsedByFollowCommands" translate="yes" xml:space="preserve">
           <source>The input gesture '{0}' is currently being used by the following commands:</source>
-          <target state="needs-review-translation">The input gesture '{0}' is currently being used by the following commands:</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Сочетание клавиш '{0}' в настоящий момент используется следующими командами:</target>
         </trans-unit>
         <trans-unit id="Orchestra_BackupAndReset" translate="yes" xml:space="preserve">
           <source>Backup and Reset</source>
-          <target state="needs-review-translation">Backup and Reset</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Сохранить резервную копию и сбросить</target>
         </trans-unit>
         <trans-unit id="Orchestra_BackupCreated" translate="yes" xml:space="preserve">
           <source>Backup has been succesfully created.</source>
-          <target state="needs-review-translation">Backup has been succesfully created.</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Резервная копия была успешно создана.</target>
         </trans-unit>
         <trans-unit id="Orchestra_BuiltOn" translate="yes" xml:space="preserve">
           <source>Built on {0}</source>
-          <target state="needs-review-translation">Built on {0}</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Собрано {0}</target>
         </trans-unit>
         <trans-unit id="Orchestra_Close" translate="yes" xml:space="preserve">
           <source>Close</source>
-          <target state="needs-review-translation">Close</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Закрыть</target>
         </trans-unit>
         <trans-unit id="Orchestra_Command" translate="yes" xml:space="preserve">
           <source>Command</source>
-          <target state="needs-review-translation">Command</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Команда</target>
         </trans-unit>
         <trans-unit id="Orchestra_Continue" translate="yes" xml:space="preserve">
           <source>Continue</source>
-          <target state="needs-review-translation">Continue</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Продолжить</target>
         </trans-unit>
         <trans-unit id="Orchestra_Copy" translate="yes" xml:space="preserve">
           <source>Copy</source>
-          <target state="needs-review-translation">Copy</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Копировать</target>
         </trans-unit>
         <trans-unit id="Orchestra_Customize" translate="yes" xml:space="preserve">
           <source>Customize</source>
-          <target state="needs-review-translation">Customize</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Кастомизировать</target>
         </trans-unit>
         <trans-unit id="Orchestra_DebugLoggingIsEnabled" translate="yes" xml:space="preserve">
           <source>Debug logging is enabled for this application instance</source>
-          <target state="needs-review-translation">Debug logging is enabled for this application instance</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Отладочное логирование включено для данного экземпляра приложения</target>
         </trans-unit>
         <trans-unit id="Orchestra_DeletedUserDataSettings" translate="yes" xml:space="preserve">
           <source>User data settings have been successfully deleted.</source>
-          <target state="needs-review-translation">User data settings have been successfully deleted.</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Пользовательские настройки были успешно удалены.</target>
         </trans-unit>
         <trans-unit id="Orchestra_EnableDetailedLogging" translate="yes" xml:space="preserve">
           <source>Enable detailed logging</source>
-          <target state="needs-review-translation">Enable detailed logging</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Включить детальное логирование</target>
         </trans-unit>
         <trans-unit id="Orchestra_EnableLogging" translate="yes" xml:space="preserve">
           <source>Enable logging</source>
-          <target state="needs-review-translation">Enable logging</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Включить логирование</target>
         </trans-unit>
         <trans-unit id="Orchestra_FailedToCreateBackup" translate="yes" xml:space="preserve">
           <source>Failed to created a backup. To prevent data loss, the application will now exit and not delete any files. Please contact support so they can guide you through the process.</source>
-          <target state="needs-review-translation">Failed to created a backup. To prevent data loss, the application will now exit and not delete any files. Please contact support so they can guide you through the process.</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Не удалось создать резервную копию. Для предотвращения потери данных, приложение будет закрыто и никакие файлы не будут удалены. Пожалуйста, обратитесь в службу технической поддержки для решения данной проблемы.</target>
         </trans-unit>
         <trans-unit id="Orchestra_InputGesture" translate="yes" xml:space="preserve">
           <source>Input gesture</source>
-          <target state="needs-review-translation">Input gesture</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Сочетание клавиш</target>
         </trans-unit>
         <trans-unit id="Orchestra_KeyboardShortcuts" translate="yes" xml:space="preserve">
           <source>Keyboard shortcuts</source>
-          <target state="needs-review-translation">Keyboard shortcuts</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Сочетания клавиш</target>
         </trans-unit>
         <trans-unit id="Orchestra_NoLogListenerAvailable" translate="yes" xml:space="preserve">
           <source>No log listener available that can be opened. Please contact support.</source>
-          <target state="needs-review-translation">No log listener available that can be opened. Please contact support.</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Нет доступных для чтения логгеров. Пожалуйста, свяжитесь со службой технической поддержки.</target>
         </trans-unit>
         <trans-unit id="Orchestra_NotStartedCorrectly_01" translate="yes" xml:space="preserve">
           <source>It seems that the application failed to start correctly the last time it was started.</source>
-          <target state="needs-review-translation">It seems that the application failed to start correctly the last time it was started.</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Судя по всему, приложение не удалось запустить в последний раз, когда оно было вызвано.</target>
         </trans-unit>
         <trans-unit id="Orchestra_NotStartedCorrectly_02" translate="yes" xml:space="preserve">
           <source>If this happens again, try to reset the user data settings. The left button will allow you to reset (and optionally backup) your settings.</source>
-          <target state="needs-review-translation">If this happens again, try to reset the user data settings. The left button will allow you to reset (and optionally backup) your settings.</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Если это повторится, попробуйте сбросить пользовательские настройки. Левая кнопка позволит вам выполнить сброс (и, при необходимости, сохранить резервную копию) ваших настроек.</target>
         </trans-unit>
         <trans-unit id="Orchestra_NotStartedCorrectly_03" translate="yes" xml:space="preserve">
           <source>When ready, click continue to start the application.</source>
-          <target state="needs-review-translation">When ready, click continue to start the application.</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Когда будете готовы, кликните "Продолжить", чтобы запустить приложение.</target>
         </trans-unit>
         <trans-unit id="Orchestra_PressShortcutKeys" translate="yes" xml:space="preserve">
           <source>Press shortcut keys:</source>
-          <target state="needs-review-translation">Press shortcut keys:</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Нажмите сочетание клавиш:</target>
         </trans-unit>
         <trans-unit id="Orchestra_Print" translate="yes" xml:space="preserve">
           <source>Print</source>
-          <target state="needs-review-translation">Print</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Печать</target>
         </trans-unit>
         <trans-unit id="Orchestra_ProducedBy" translate="yes" xml:space="preserve">
           <source>Produced by {0}</source>
-          <target state="needs-review-translation">Produced by {0}</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Произведено {0}</target>
         </trans-unit>
         <trans-unit id="Orchestra_ReleasedOn" translate="yes" xml:space="preserve">
           <source>Released on</source>
-          <target state="needs-review-translation">Released on</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Выпущено</target>
         </trans-unit>
         <trans-unit id="Orchestra_Remove" translate="yes" xml:space="preserve">
           <source>Remove</source>
-          <target state="needs-review-translation">Remove</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Удалить</target>
         </trans-unit>
         <trans-unit id="Orchestra_ReplaceInputGesture" translate="yes" xml:space="preserve">
           <source>Replace input gesture?</source>
-          <target state="needs-review-translation">Replace input gesture?</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Заменить сочетание клавиш?</target>
         </trans-unit>
         <trans-unit id="Orchestra_Reset" translate="yes" xml:space="preserve">
           <source>Reset</source>
-          <target state="needs-review-translation">Reset</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Сброс</target>
         </trans-unit>
         <trans-unit id="Orchestra_ResetKeyboardShortcutsAreYouSure" translate="yes" xml:space="preserve">
           <source>Resetting shortcuts will delete all your current shortcuts. This action cannot be undone. Are you sure you want to reset the shortcuts?</source>
-          <target state="needs-review-translation">Resetting shortcuts will delete all your current shortcuts. This action cannot be undone. Are you sure you want to reset the shortcuts?</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Сброс сочетаний клавиш удалит все ваши сочетания. Это действие не может быть отменено. Вы уверены, что хотите сбросить сочетания клавиш?</target>
         </trans-unit>
         <trans-unit id="Orchestra_RetrievingSystemInfo" translate="yes" xml:space="preserve">
           <source>Retrieving system information...</source>
-          <target state="needs-review-translation">Retrieving system information...</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Получение информации о системе...</target>
         </trans-unit>
         <trans-unit id="Orchestra_ShortcutForSelectedCommand" translate="yes" xml:space="preserve">
           <source>Shortcut for selected command:</source>
-          <target state="needs-review-translation">Shortcut for selected command:</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Сочетание для выбранной команды:</target>
         </trans-unit>
         <trans-unit id="Orchestra_ShortcutsForApplication" translate="yes" xml:space="preserve">
           <source>Keyboard shortcuts for {0}</source>
-          <target state="needs-review-translation">Keyboard shortcuts for {0}</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Сочетание клавиш для {0}</target>
         </trans-unit>
         <trans-unit id="Orchestra_ShowCommandsContaining" translate="yes" xml:space="preserve">
           <source>Show commands containing:</source>
-          <target state="needs-review-translation">Show commands containing:</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Показать команды, содержащие:</target>
         </trans-unit>
         <trans-unit id="Orchestra_ShowLog" translate="yes" xml:space="preserve">
           <source>Show log...</source>
-          <target state="needs-review-translation">Show log...</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Показать лог...</target>
         </trans-unit>
         <trans-unit id="Orchestra_ShowSystemInfo" translate="yes" xml:space="preserve">
           <source>Show system info</source>
-          <target state="needs-review-translation">Show system info</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Показать информацию о системе</target>
         </trans-unit>
         <trans-unit id="Orchestra_SystemInfo" translate="yes" xml:space="preserve">
           <source>System information</source>
-          <target state="needs-review-translation">System information</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Информация о системе</target>
         </trans-unit>
         <trans-unit id="Orchestra_UserDataSettings" translate="yes" xml:space="preserve">
           <source>User data settings</source>
-          <target state="needs-review-translation">User data settings</target>
-          <note from="MultilingualUpdate" priority="2">When the XLIFF file support was added via MAT, existing resources were found and auto-imported.  This source and target string contained the same value so the resource was marked as 'Needs review' to ensure the translation could be easily reviewed.</note>
+          <target state="translated">Пользовательские настройки</target>
         </trans-unit>
       </group>
     </body>

--- a/src/Orchestra.Core/Properties/Resources.ru.resx
+++ b/src/Orchestra.Core/Properties/Resources.ru.resx
@@ -91,7 +91,7 @@
     <value>Произведено {0}</value>
   </data>
   <data name="Orchestra_ReleasedOn" xml:space="preserve">
-    <value>Выпущено </value>
+    <value>Выпущено</value>
   </data>
   <data name="Orchestra_Remove" xml:space="preserve">
     <value>Удалить</value>

--- a/src/Orchestra.Core/Properties/Resources.ru.resx
+++ b/src/Orchestra.Core/Properties/Resources.ru.resx
@@ -13,120 +13,120 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Orchestra_AllRightsReserved" xml:space="preserve">
-    <value>All rights reserved</value>
+    <value>Все права сохранены</value>
   </data>
   <data name="Orchestra_Assign" xml:space="preserve">
-    <value>Assign</value>
+    <value>Привязать</value>
   </data>
   <data name="Orchestra_AssignInputGestureAreYouSure" xml:space="preserve">
-    <value>Are you sure you want to assign the input gesture to '{0}'. It will be removed from the other commands.</value>
+    <value>Вы уверены, что хотите привязать сочетание клавиш к '{0}'? Оно будет удалено для остальных команд.</value>
   </data>
   <data name="Orchestra_AssignInputGestureUsedByFollowCommands" xml:space="preserve">
-    <value>The input gesture '{0}' is currently being used by the following commands:</value>
+    <value>Сочетание клавиш '{0}' в настоящий момент используется следующими командами:</value>
   </data>
   <data name="Orchestra_BackupAndReset" xml:space="preserve">
-    <value>Backup and Reset</value>
+    <value>Сохранить резервную копию и сбросить</value>
   </data>
   <data name="Orchestra_BackupCreated" xml:space="preserve">
-    <value>Backup has been succesfully created.</value>
+    <value>Резервная копия была успешно создана.</value>
   </data>
   <data name="Orchestra_BuiltOn" xml:space="preserve">
-    <value>Built on {0}</value>
+    <value>Собрано {0}</value>
   </data>
   <data name="Orchestra_Close" xml:space="preserve">
-    <value>Close</value>
+    <value>Закрыть</value>
   </data>
   <data name="Orchestra_Command" xml:space="preserve">
-    <value>Command</value>
+    <value>Команда</value>
   </data>
   <data name="Orchestra_Continue" xml:space="preserve">
-    <value>Continue</value>
+    <value>Продолжить</value>
   </data>
   <data name="Orchestra_Copy" xml:space="preserve">
-    <value>Copy</value>
+    <value>Копировать</value>
   </data>
   <data name="Orchestra_Customize" xml:space="preserve">
-    <value>Customize</value>
+    <value>Кастомизировать</value>
   </data>
   <data name="Orchestra_DebugLoggingIsEnabled" xml:space="preserve">
-    <value>Debug logging is enabled for this application instance</value>
+    <value>Отладочное логирование включено для данного экземпляра приложения</value>
   </data>
   <data name="Orchestra_DeletedUserDataSettings" xml:space="preserve">
-    <value>User data settings have been successfully deleted.</value>
+    <value>Пользовательские настройки были успешно удалены.</value>
   </data>
   <data name="Orchestra_EnableDetailedLogging" xml:space="preserve">
-    <value>Enable detailed logging</value>
+    <value>Включить детальное логирование</value>
   </data>
   <data name="Orchestra_EnableLogging" xml:space="preserve">
-    <value>Enable logging</value>
+    <value>Включить логирование</value>
   </data>
   <data name="Orchestra_FailedToCreateBackup" xml:space="preserve">
-    <value>Failed to created a backup. To prevent data loss, the application will now exit and not delete any files. Please contact support so they can guide you through the process.</value>
+    <value>Не удалось создать резервную копию. Для предотвращения потери данных, приложение будет закрыто и никакие файлы не будут удалены. Пожалуйста, обратитесь в службу технической поддержки для решения данной проблемы.</value>
   </data>
   <data name="Orchestra_InputGesture" xml:space="preserve">
-    <value>Input gesture</value>
+    <value>Сочетание клавиш</value>
   </data>
   <data name="Orchestra_KeyboardShortcuts" xml:space="preserve">
-    <value>Keyboard shortcuts</value>
+    <value>Сочетания клавиш</value>
   </data>
   <data name="Orchestra_NoLogListenerAvailable" xml:space="preserve">
-    <value>No log listener available that can be opened. Please contact support.</value>
+    <value>Нет доступных для чтения логгеров. Пожалуйста, свяжитесь со службой технической поддержки.</value>
   </data>
   <data name="Orchestra_NotStartedCorrectly_01" xml:space="preserve">
-    <value>It seems that the application failed to start correctly the last time it was started.</value>
+    <value>Судя по всему, приложение не удалось запустить в последний раз, когда оно было вызвано.</value>
   </data>
   <data name="Orchestra_NotStartedCorrectly_02" xml:space="preserve">
-    <value>If this happens again, try to reset the user data settings. The left button will allow you to reset (and optionally backup) your settings.</value>
+    <value>Если это повторится, попробуйте сбросить пользовательские настройки. Левая кнопка позволит вам выполнить сброс (и, при необходимости, сохранить резервную копию) ваших настроек.</value>
   </data>
   <data name="Orchestra_NotStartedCorrectly_03" xml:space="preserve">
-    <value>When ready, click continue to start the application.</value>
+    <value>Когда будете готовы, кликните "Продолжить", чтобы запустить приложение.</value>
   </data>
   <data name="Orchestra_PressShortcutKeys" xml:space="preserve">
-    <value>Press shortcut keys:</value>
+    <value>Нажмите сочетание клавиш:</value>
   </data>
   <data name="Orchestra_Print" xml:space="preserve">
-    <value>Print</value>
+    <value>Печать</value>
   </data>
   <data name="Orchestra_ProducedBy" xml:space="preserve">
-    <value>Produced by {0}</value>
+    <value>Произведено {0}</value>
   </data>
   <data name="Orchestra_ReleasedOn" xml:space="preserve">
-    <value>Released on</value>
+    <value>Выпущено </value>
   </data>
   <data name="Orchestra_Remove" xml:space="preserve">
-    <value>Remove</value>
+    <value>Удалить</value>
   </data>
   <data name="Orchestra_ReplaceInputGesture" xml:space="preserve">
-    <value>Replace input gesture?</value>
+    <value>Заменить сочетание клавиш?</value>
   </data>
   <data name="Orchestra_Reset" xml:space="preserve">
-    <value>Reset</value>
+    <value>Сброс</value>
   </data>
   <data name="Orchestra_ResetKeyboardShortcutsAreYouSure" xml:space="preserve">
-    <value>Resetting shortcuts will delete all your current shortcuts. This action cannot be undone. Are you sure you want to reset the shortcuts?</value>
+    <value>Сброс сочетаний клавиш удалит все ваши сочетания. Это действие не может быть отменено. Вы уверены, что хотите сбросить сочетания клавиш?</value>
   </data>
   <data name="Orchestra_RetrievingSystemInfo" xml:space="preserve">
-    <value>Retrieving system information...</value>
+    <value>Получение информации о системе...</value>
   </data>
   <data name="Orchestra_ShortcutForSelectedCommand" xml:space="preserve">
-    <value>Shortcut for selected command:</value>
+    <value>Сочетание для выбранной команды:</value>
   </data>
   <data name="Orchestra_ShortcutsForApplication" xml:space="preserve">
-    <value>Keyboard shortcuts for {0}</value>
+    <value>Сочетание клавиш для {0}</value>
   </data>
   <data name="Orchestra_ShowCommandsContaining" xml:space="preserve">
-    <value>Show commands containing:</value>
+    <value>Показать команды, содержащие:</value>
   </data>
   <data name="Orchestra_ShowLog" xml:space="preserve">
-    <value>Show log...</value>
+    <value>Показать лог...</value>
   </data>
   <data name="Orchestra_ShowSystemInfo" xml:space="preserve">
-    <value>Show system info</value>
+    <value>Показать информацию о системе</value>
   </data>
   <data name="Orchestra_SystemInfo" xml:space="preserve">
-    <value>System information</value>
+    <value>Информация о системе</value>
   </data>
   <data name="Orchestra_UserDataSettings" xml:space="preserve">
-    <value>User data settings</value>
+    <value>Пользовательские настройки</value>
   </data>
 </root>

--- a/src/Orchestra.Core/Properties/Resources.ru.resx
+++ b/src/Orchestra.Core/Properties/Resources.ru.resx
@@ -13,7 +13,7 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <data name="Orchestra_AllRightsReserved" xml:space="preserve">
-    <value>Все права сохранены</value>
+    <value>Все права защищены</value>
   </data>
   <data name="Orchestra_Assign" xml:space="preserve">
     <value>Привязать</value>
@@ -70,7 +70,7 @@
     <value>Сочетания клавиш</value>
   </data>
   <data name="Orchestra_NoLogListenerAvailable" xml:space="preserve">
-    <value>Нет доступных для чтения логгеров. Пожалуйста, свяжитесь со службой технической поддержки.</value>
+    <value>Нет логгеров, которые можно было бы использовать. Пожалуйста, свяжитесь со службой технической поддержки.</value>
   </data>
   <data name="Orchestra_NotStartedCorrectly_01" xml:space="preserve">
     <value>Судя по всему, приложение не удалось запустить в последний раз, когда оно было вызвано.</value>
@@ -82,7 +82,7 @@
     <value>Когда будете готовы, кликните "Продолжить", чтобы запустить приложение.</value>
   </data>
   <data name="Orchestra_PressShortcutKeys" xml:space="preserve">
-    <value>Нажмите сочетание клавиш:</value>
+    <value>Используйте сочетание клавиш:</value>
   </data>
   <data name="Orchestra_Print" xml:space="preserve">
     <value>Печать</value>

--- a/src/Orchestra.Core/Views/AboutWindow.xaml
+++ b/src/Orchestra.Core/Views/AboutWindow.xaml
@@ -72,9 +72,9 @@
                    Visibility="{Binding IsDebugLoggingEnabled, Converter={catel:BooleanToCollapsingVisibilityConverter}}" />
 
         <StackPanel Grid.Row="11" Orientation="Horizontal" HorizontalAlignment="Center" Margin="20 0 20 0">
-            <Button Content="{catel:LanguageBinding Orchestra_ShowLog}" Width="75" Margin="0 20 15 30" Command="{Binding OpenLog}"
+            <Button Content="{catel:LanguageBinding Orchestra_ShowLog}" Width="80" Margin="0 20 15 30" Command="{Binding OpenLog}"
                     Visibility="{Binding ShowLogButton, Converter={StaticResource BooleanToCollapsingVisibilityConverter}}" />
-            <Button Content="{catel:LanguageBinding Orchestra_Close}" Width="75" Margin="0 20 0 30" Click="Close_OnClick" />
+            <Button Content="{catel:LanguageBinding Orchestra_Close}" Width="80" Margin="0 20 0 30" Click="Close_OnClick" />
         </StackPanel>
     </Grid>
 

--- a/src/Orchestra.Core/Views/CrashWarningWindow.xaml
+++ b/src/Orchestra.Core/Views/CrashWarningWindow.xaml
@@ -80,7 +80,7 @@
                 <TextBlock Text="{catel:LanguageBinding Orchestra_NotStartedCorrectly_03}" TextWrapping="Wrap" Margin="0 0 0 12" />
 
                 <DockPanel Margin="0 20 0 0" LastChildFill="False" VerticalAlignment="Top">
-                    <orccontrols:DropDownButton Header="{catel:LanguageBinding Orchestra_UserDataSettings}" DockPanel.Dock="Left" Height="26" Width="140"
+                    <orccontrols:DropDownButton Header="{catel:LanguageBinding Orchestra_UserDataSettings}" DockPanel.Dock="Left" Height="26" MinWidth="140"
                                         AccentColorBrush="{DynamicResource AccentColorBrush}" ShowDefaultButton="False"
                                         Style="{StaticResource CrashWarningWindowDropDownButtonStyle}">
                         <orccontrols:DropDownButton.DropDown>
@@ -91,7 +91,7 @@
                         </orccontrols:DropDownButton.DropDown>
                     </orccontrols:DropDownButton>
 
-                    <Button Content="{catel:LanguageBinding Orchestra_Continue}" DockPanel.Dock="Right" Width="70" Height="26" 
+                    <Button Content="{catel:LanguageBinding Orchestra_Continue}" DockPanel.Dock="Right" MinWidth="70" Height="26" 
                             IsDefault="true" Command="{Binding Continue}" Style="{StaticResource CrashWarningWindowButtonStyle}"/>
                 </DockPanel>
             </StackPanel>


### PR DESCRIPTION
### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

Added russian translation. Tried to keep the meanings of phrases but use more suitable language constructs:
 - Translated `Assign` as `Привязать` which is actually `Bind`. Sounds more natural then `Назначить`.
 - Translated `Input gesture` as `Сочетание клавиш` which is simillar to `Keyboard shortcut`. I have never seen the word `Gesture` (`Жест`) used for keyboard shortcuts binding (except multi-touch or touchpad **gestures**, of course).
 - Translated `Please contact support so they can guide you through the process.` as `Пожалуйста, обратитесь в службу технической поддержки для решения данной проблемы.` which can roughly be translated back as `Please contact technical support to resolve this problem`.
- Translated `Log listener` as `Логгер` (`Logger`). As far as I know, there is no vebratim translation of such term.

Also changed a few button's `Width`'s to fit lengthy strings.