### PR TITLE
Added BaseColorService similar to AccentColorService

### DIFF
--- a/src/Orchestra.Core/ModuleInitializer.cs
+++ b/src/Orchestra.Core/ModuleInitializer.cs
@@ -58,7 +58,7 @@ public static class ModuleInitializer
         serviceLocator.RegisterTypeIfNotYetRegistered<IAboutInfoService, AboutInfoService>();
         serviceLocator.RegisterTypeIfNotYetRegistered<IAboutService, AboutService>();
         serviceLocator.RegisterTypeIfNotYetRegistered<IClipboardService, ClipboardService>();
-        serviceLocator.RegisterTypeIfNotYetRegistered<IBaseColorService, BaseColorService>();
+        serviceLocator.RegisterTypeIfNotYetRegistered<IBaseColorSchemeService, BaseColorSchemeService>();
         serviceLocator.RegisterTypeIfNotYetRegistered<IThemeService, ThemeService>();
         serviceLocator.RegisterTypeIfNotYetRegistered<IViewActivationService, ViewActivationService>();
 

--- a/src/Orchestra.Core/ModuleInitializer.cs
+++ b/src/Orchestra.Core/ModuleInitializer.cs
@@ -58,6 +58,7 @@ public static class ModuleInitializer
         serviceLocator.RegisterTypeIfNotYetRegistered<IAboutInfoService, AboutInfoService>();
         serviceLocator.RegisterTypeIfNotYetRegistered<IAboutService, AboutService>();
         serviceLocator.RegisterTypeIfNotYetRegistered<IClipboardService, ClipboardService>();
+        serviceLocator.RegisterTypeIfNotYetRegistered<IBaseColorService, BaseColorService>();
         serviceLocator.RegisterTypeIfNotYetRegistered<IThemeService, ThemeService>();
         serviceLocator.RegisterTypeIfNotYetRegistered<IViewActivationService, ViewActivationService>();
 

--- a/src/Orchestra.Core/OrchestraEnvironment.cs
+++ b/src/Orchestra.Core/OrchestraEnvironment.cs
@@ -12,6 +12,7 @@ namespace Orchestra
     public static class OrchestraEnvironment
     {
         #region Constants
+        public const string DefaultBaseColor = "Light";
         public static readonly SolidColorBrush DefaultAccentColorBrush = new SolidColorBrush(Colors.Orange);
         #endregion
     }

--- a/src/Orchestra.Core/OrchestraEnvironment.cs
+++ b/src/Orchestra.Core/OrchestraEnvironment.cs
@@ -12,7 +12,9 @@ namespace Orchestra
     public static class OrchestraEnvironment
     {
         #region Constants
-        public const string DefaultBaseColor = "Light";
+        public const string LightBaseColorScheme = "Light";
+        public const string DarkBaseColorScheme = "Dark";
+        public const string DefaultBaseColorSchema = LightBaseColorScheme;
         public static readonly SolidColorBrush DefaultAccentColorBrush = new SolidColorBrush(Colors.Orange);
         #endregion
     }

--- a/src/Orchestra.Core/Services/BaseColorService.cs
+++ b/src/Orchestra.Core/Services/BaseColorService.cs
@@ -7,24 +7,28 @@
     using System.Threading.Tasks;
     using Catel;
 
-    public class BaseColorService : IBaseColorService
+    public class BaseColorSchemeService : IBaseColorSchemeService
     {
-        public event EventHandler<EventArgs> BaseColorChanged;
-        
-        private string _baseColor = null;
-        public string GetBaseColor() => _baseColor ?? (_baseColor = GetAvailableBaseColors()[0]);
-        public bool SetBaseColor(string color)
+        public event EventHandler<EventArgs> BaseColorSchemeChanged;
+
+        private string _baseColorScheme = null;
+
+        public string GetBaseColorScheme() => _baseColorScheme ?? (_baseColorScheme = GetAvailableBaseColorSchemes()[0]);
+
+        public bool SetBaseColorScheme(string color)
         {
-            if (_baseColor == color || !GetAvailableBaseColors().Contains(color))
-                return false;
-            _baseColor = color;
-            BaseColorChanged?.Invoke(this, EventArgs.Empty);
+            if (_baseColorScheme.EqualsIgnoreCase(color) || !GetAvailableBaseColorSchemes().Contains(color))
+            { 
+                return false; 
+            }
+            _baseColorScheme = color;
+            BaseColorSchemeChanged?.Invoke(this, EventArgs.Empty);
             return true;
         }
-       
-        public virtual IReadOnlyList<string> GetAvailableBaseColors()
+
+        public virtual IReadOnlyList<string> GetAvailableBaseColorSchemes()
         {
-            return new List<string>() { OrchestraEnvironment.DefaultBaseColor }.AsReadOnly();
+            return new List<string>() { OrchestraEnvironment.LightBaseColorScheme }.AsReadOnly();
         }
     }
 }

--- a/src/Orchestra.Core/Services/BaseColorService.cs
+++ b/src/Orchestra.Core/Services/BaseColorService.cs
@@ -1,0 +1,25 @@
+﻿namespace Orchestra.Services
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    public class BaseColorService : IBaseColorService
+    {
+        public event EventHandler<EventArgs> BaseColorChanged;
+
+        public string BaseColor = null;
+        public string GetBaseColor() => BaseColor ?? (BaseColor = "Light");
+
+
+        public void SetBaseColor(string color)
+        {
+            if (BaseColor == color)
+                return;
+            BaseColor = color;
+            BaseColorChanged?.Invoke(this, EventArgs.Empty);
+        }
+    }
+}

--- a/src/Orchestra.Core/Services/BaseColorService.cs
+++ b/src/Orchestra.Core/Services/BaseColorService.cs
@@ -5,21 +5,26 @@
     using System.Linq;
     using System.Text;
     using System.Threading.Tasks;
+    using Catel;
 
     public class BaseColorService : IBaseColorService
     {
         public event EventHandler<EventArgs> BaseColorChanged;
-
-        public string BaseColor = null;
-        public string GetBaseColor() => BaseColor ?? (BaseColor = "Light");
-
-
-        public void SetBaseColor(string color)
+        
+        private string _baseColor = null;
+        public string GetBaseColor() => _baseColor ?? (_baseColor = GetAvailableBaseColors()[0]);
+        public bool SetBaseColor(string color)
         {
-            if (BaseColor == color)
-                return;
-            BaseColor = color;
+            if (_baseColor == color || !GetAvailableBaseColors().Contains(color))
+                return false;
+            _baseColor = color;
             BaseColorChanged?.Invoke(this, EventArgs.Empty);
+            return true;
+        }
+       
+        public virtual IReadOnlyList<string> GetAvailableBaseColors()
+        {
+            return new List<string>() { OrchestraEnvironment.DefaultBaseColor }.AsReadOnly();
         }
     }
 }

--- a/src/Orchestra.Core/Services/Interfaces/IBaseColorService.cs
+++ b/src/Orchestra.Core/Services/Interfaces/IBaseColorService.cs
@@ -1,0 +1,13 @@
+﻿namespace Orchestra.Services
+{
+    using System;
+    using System.Windows.Media;
+
+    public interface IBaseColorService
+    {
+        event EventHandler<EventArgs> BaseColorChanged;
+
+        string GetBaseColor();
+        void SetBaseColor(string color);
+    }
+}

--- a/src/Orchestra.Core/Services/Interfaces/IBaseColorService.cs
+++ b/src/Orchestra.Core/Services/Interfaces/IBaseColorService.cs
@@ -1,13 +1,20 @@
 ﻿namespace Orchestra.Services
 {
     using System;
+    using System.Collections.Generic;
     using System.Windows.Media;
 
     public interface IBaseColorService
     {
         event EventHandler<EventArgs> BaseColorChanged;
 
+        /// <summary>
+        /// returns the available base colors (at least one)
+        /// </summary>
+        /// <returns>at least one base color, otherwise GetBaseColor will throw an exception</returns>
+        IReadOnlyList<string> GetAvailableBaseColors();
+
         string GetBaseColor();
-        void SetBaseColor(string color);
+        bool SetBaseColor(string color);
     }
 }

--- a/src/Orchestra.Core/Services/Interfaces/IBaseColorService.cs
+++ b/src/Orchestra.Core/Services/Interfaces/IBaseColorService.cs
@@ -4,17 +4,17 @@
     using System.Collections.Generic;
     using System.Windows.Media;
 
-    public interface IBaseColorService
+    public interface IBaseColorSchemeService
     {
-        event EventHandler<EventArgs> BaseColorChanged;
+        event EventHandler<EventArgs> BaseColorSchemeChanged;
 
         /// <summary>
         /// returns the available base colors (at least one)
         /// </summary>
         /// <returns>at least one base color, otherwise GetBaseColor will throw an exception</returns>
-        IReadOnlyList<string> GetAvailableBaseColors();
+        IReadOnlyList<string> GetAvailableBaseColorSchemes();
 
-        string GetBaseColor();
-        bool SetBaseColor(string color);
+        string GetBaseColorScheme();
+        bool SetBaseColorScheme(string color);
     }
 }

--- a/src/Orchestra.Core/Services/ThemeService.cs
+++ b/src/Orchestra.Core/Services/ThemeService.cs
@@ -11,12 +11,15 @@ namespace Orchestra.Services
     public class ThemeService : IThemeService
     {
         private readonly Orc.Controls.Services.IAccentColorService _accentColorService;
+        private readonly IBaseColorService _baseColorService;
 
-        public ThemeService(Orc.Controls.Services.IAccentColorService accentColorService)
+        public ThemeService(Orc.Controls.Services.IAccentColorService accentColorService,IBaseColorService baseColorService)
         {
             Argument.IsNotNull(() => accentColorService);
+            Argument.IsNotNull(() => baseColorService);
 
             _accentColorService = accentColorService;
+            _baseColorService = baseColorService;
         }
 
         public virtual bool ShouldCreateStyleForwarders()
@@ -30,7 +33,7 @@ namespace Orchestra.Services
 
             var themeInfo = new ThemeInfo
             {
-                BaseColorScheme = "Light",
+                BaseColorScheme = _baseColorService.GetBaseColor(),
                 AccentBaseColor = accentColor,
                 HighlightColor = accentColor
             };

--- a/src/Orchestra.Core/Services/ThemeService.cs
+++ b/src/Orchestra.Core/Services/ThemeService.cs
@@ -11,15 +11,15 @@ namespace Orchestra.Services
     public class ThemeService : IThemeService
     {
         private readonly Orc.Controls.Services.IAccentColorService _accentColorService;
-        private readonly IBaseColorService _baseColorService;
+        private readonly IBaseColorSchemeService _baseColorSchemeService;
 
-        public ThemeService(Orc.Controls.Services.IAccentColorService accentColorService,IBaseColorService baseColorService)
+        public ThemeService(Orc.Controls.Services.IAccentColorService accentColorService,IBaseColorSchemeService baseColorSchemeService)
         {
             Argument.IsNotNull(() => accentColorService);
-            Argument.IsNotNull(() => baseColorService);
+            Argument.IsNotNull(() => baseColorSchemeService);
 
             _accentColorService = accentColorService;
-            _baseColorService = baseColorService;
+            _baseColorSchemeService = baseColorSchemeService;
         }
 
         public virtual bool ShouldCreateStyleForwarders()
@@ -33,7 +33,7 @@ namespace Orchestra.Services
 
             var themeInfo = new ThemeInfo
             {
-                BaseColorScheme = _baseColorService.GetBaseColor(),
+                BaseColorScheme = _baseColorSchemeService.GetBaseColorScheme(),
                 AccentBaseColor = accentColor,
                 HighlightColor = accentColor
             };

--- a/src/Orchestra.Examples.Shared/ViewModels/ControlsViewModel.cs
+++ b/src/Orchestra.Examples.Shared/ViewModels/ControlsViewModel.cs
@@ -12,29 +12,29 @@
     public class ControlsViewModel : ViewModelBase
     {
         private readonly Orc.Controls.Services.IAccentColorService _accentColorService;
-        private readonly IBaseColorService _baseColorService;
+        private readonly IBaseColorSchemeService _baseColorSchemeService;
 
-        public ControlsViewModel(Orc.Controls.Services.IAccentColorService accentColorService, IBaseColorService baseColorService)
+        public ControlsViewModel(Orc.Controls.Services.IAccentColorService accentColorService, IBaseColorSchemeService baseColorSchemeService)
         {
             Argument.IsNotNull(() => accentColorService);
-            Argument.IsNotNull(() => baseColorService);
+            Argument.IsNotNull(() => baseColorSchemeService);
 
             _accentColorService = accentColorService;
-            _baseColorService = baseColorService;
+            _baseColorSchemeService = baseColorSchemeService;
 
             AccentColors = typeof(Colors).GetPropertiesEx(true, true).Where(x => x.PropertyType.IsAssignableFromEx(typeof(Color))).Select(x => (Color)x.GetValue(null)).ToList();
             SelectedAccentColor = Colors.Orange;
 
-            BaseColors = _baseColorService.GetAvailableBaseColors();
-            SelectedBaseColor = BaseColors[0];
+            BaseColorSchemes = _baseColorSchemeService.GetAvailableBaseColorSchemes();
+            SelectedBaseColorScheme = BaseColorSchemes[0];
         }
 
         #region
         public List<Color> AccentColors { get; private set; }
-        public IReadOnlyList<string> BaseColors { get; private set; }
+        public IReadOnlyList<string> BaseColorSchemes { get; private set; }
 
         public Color SelectedAccentColor { get; set; }
-        public string SelectedBaseColor { get; set; }
+        public string SelectedBaseColorScheme { get; set; }
         #endregion
 
         #region Methods
@@ -42,9 +42,10 @@
         {
             _accentColorService.SetAccentColor(SelectedAccentColor);
         }
-        private void OnSelectedBaseColorChanged()
+
+        private void OnSelectedBaseColorSchemeChanged()
         {
-            _baseColorService.SetBaseColor(SelectedBaseColor);
+            _baseColorSchemeService.SetBaseColorScheme(SelectedBaseColorScheme);
         }
         #endregion
     }

--- a/src/Orchestra.Examples.Shared/ViewModels/ControlsViewModel.cs
+++ b/src/Orchestra.Examples.Shared/ViewModels/ControlsViewModel.cs
@@ -7,31 +7,44 @@
     using Catel.MVVM;
     using Catel.Reflection;
     using Orc.Controls.Services;
+    using Orchestra.Services;
 
     public class ControlsViewModel : ViewModelBase
     {
-        private IAccentColorService _accentColorService;
+        private readonly Orc.Controls.Services.IAccentColorService _accentColorService;
+        private readonly IBaseColorService _baseColorService;
 
-        public ControlsViewModel(IAccentColorService accentColorService)
+        public ControlsViewModel(Orc.Controls.Services.IAccentColorService accentColorService, IBaseColorService baseColorService)
         {
             Argument.IsNotNull(() => accentColorService);
+            Argument.IsNotNull(() => baseColorService);
 
             _accentColorService = accentColorService;
+            _baseColorService = baseColorService;
 
             AccentColors = typeof(Colors).GetPropertiesEx(true, true).Where(x => x.PropertyType.IsAssignableFromEx(typeof(Color))).Select(x => (Color)x.GetValue(null)).ToList();
             SelectedAccentColor = Colors.Orange;
+
+            BaseColors = _baseColorService.GetAvailableBaseColors();
+            SelectedBaseColor = BaseColors[0];
         }
 
         #region
         public List<Color> AccentColors { get; private set; }
+        public IReadOnlyList<string> BaseColors { get; private set; }
 
         public Color SelectedAccentColor { get; set; }
+        public string SelectedBaseColor { get; set; }
         #endregion
 
         #region Methods
         private void OnSelectedAccentColorChanged()
         {
             _accentColorService.SetAccentColor(SelectedAccentColor);
+        }
+        private void OnSelectedBaseColorChanged()
+        {
+            _baseColorService.SetBaseColor(SelectedBaseColor);
         }
         #endregion
     }

--- a/src/Orchestra.Examples.Shared/Views/ControlsView.xaml
+++ b/src/Orchestra.Examples.Shared/Views/ControlsView.xaml
@@ -15,29 +15,48 @@
       <RowDefinition Height="*" />
     </Grid.RowDefinitions>
 
-    <StackPanel Grid.Row="0" Orientation="Horizontal">
-      <Label Content="Select the accent color" />
-      <ComboBox ItemsSource="{Binding AccentColors}" SelectedItem="{Binding SelectedAccentColor}">
-        <ComboBox.ItemTemplate>
-          <DataTemplate>
-            <Grid>
-              <Grid.ColumnDefinitions>
-                <ColumnDefinition Width="Auto" />
-                <ColumnDefinition Width="*" />
-              </Grid.ColumnDefinitions>
+    <Grid Grid.Row="0">
+      <Grid.ColumnDefinitions>
+        <ColumnDefinition Width="*"/>
+        <ColumnDefinition Width="*"/>
+      </Grid.ColumnDefinitions>
+      <StackPanel Orientation="Horizontal">
+        <Label Content="Select the accent color" />
+        <ComboBox ItemsSource="{Binding AccentColors}" SelectedItem="{Binding SelectedAccentColor}">
+          <ComboBox.ItemTemplate>
+            <DataTemplate>
+              <Grid>
+                <Grid.ColumnDefinitions>
+                  <ColumnDefinition Width="Auto" />
+                  <ColumnDefinition Width="*" />
+                </Grid.ColumnDefinitions>
 
-              <Rectangle Grid.Column="0" Width="20" Height="12" VerticalAlignment="Center" Margin="4,2,8,2">
-                <Rectangle.Fill>
-                  <SolidColorBrush Color="{Binding }" />
-                </Rectangle.Fill>
-              </Rectangle>
+                <Rectangle Grid.Column="0" Width="20" Height="12" VerticalAlignment="Center" Margin="4,2,8,2">
+                  <Rectangle.Fill>
+                    <SolidColorBrush Color="{Binding }" />
+                  </Rectangle.Fill>
+                </Rectangle>
 
-              <TextBlock Grid.Column="1" Text="{Binding }" VerticalAlignment="Center" />
-            </Grid>
-          </DataTemplate>
-        </ComboBox.ItemTemplate>
-      </ComboBox>
-    </StackPanel>
+                <TextBlock Grid.Column="1" Text="{Binding }" VerticalAlignment="Center" />
+              </Grid>
+            </DataTemplate>
+          </ComboBox.ItemTemplate>
+        </ComboBox>
+      </StackPanel>
+
+      <StackPanel Grid.Column="1" Orientation="Horizontal">
+        <Label Content="Select the base color" />
+        <ComboBox ItemsSource="{Binding BaseColors}" SelectedItem="{Binding SelectedBaseColor}">
+          <ComboBox.ItemTemplate>
+            <DataTemplate>
+              <Grid>
+                <TextBlock Grid.Column="1" Text="{Binding }" VerticalAlignment="Center" />
+              </Grid>
+            </DataTemplate>
+          </ComboBox.ItemTemplate>
+        </ComboBox>
+      </StackPanel>
+    </Grid>
 
     <orccontrols:StackGrid Grid.Row="1">
       <Grid.RowDefinitions>
@@ -101,8 +120,8 @@
 
       <GroupBox Header="Orc controls">
         <WrapPanel>
-            <orccontrols:BusyIndicator ToolTip="Orchestra: BusyIndicator" Width="100" Height="12" />
-            <orccontrols:FluidProgressBar ToolTip="Orchestra: FluidProgressBar" Width="100" Height="12" />
+          <orccontrols:BusyIndicator ToolTip="Orchestra: BusyIndicator" Width="100" Height="12" />
+          <orccontrols:FluidProgressBar ToolTip="Orchestra: FluidProgressBar" Width="100" Height="12" />
         </WrapPanel>
       </GroupBox>
 
@@ -125,12 +144,12 @@
                     Height="200" 
                     ToolTip="ListView">
 
-              <ListView.Items>
-                  Item 11
+            <ListView.Items>
+              Item 11
                   Item 21
                   Item 31
                   Item 41
-              </ListView.Items>
+            </ListView.Items>
           </ListView>
 
           <TreeView Width="100" Height="200" ToolTip="TreeView" />

--- a/src/Orchestra.Examples.Shared/Views/ControlsView.xaml
+++ b/src/Orchestra.Examples.Shared/Views/ControlsView.xaml
@@ -46,7 +46,7 @@
 
       <StackPanel Grid.Column="1" Orientation="Horizontal">
         <Label Content="Select the base color" />
-        <ComboBox ItemsSource="{Binding BaseColors}" SelectedItem="{Binding SelectedBaseColor}">
+        <ComboBox ItemsSource="{Binding BaseColorSchemes}" SelectedItem="{Binding SelectedBaseColorScheme}">
           <ComboBox.ItemTemplate>
             <DataTemplate>
               <Grid>

--- a/src/Orchestra.Shell.MahApps/ModuleInitializer.cs
+++ b/src/Orchestra.Shell.MahApps/ModuleInitializer.cs
@@ -22,7 +22,7 @@ public static partial class ModuleInitializer
     {
         var serviceLocator = ServiceLocator.Default;
 
-        serviceLocator.RegisterType<IBaseColorService, BaseColorService>();
+        serviceLocator.RegisterType<IBaseColorService, MahAppsBaseColorService>();
         serviceLocator.RegisterType<IFlyoutService, FlyoutService>();
         serviceLocator.RegisterType<IAboutService, MahAppsAboutService>();
         serviceLocator.RegisterType<IMessageService, MahAppsMessageService>();

--- a/src/Orchestra.Shell.MahApps/ModuleInitializer.cs
+++ b/src/Orchestra.Shell.MahApps/ModuleInitializer.cs
@@ -22,6 +22,7 @@ public static partial class ModuleInitializer
     {
         var serviceLocator = ServiceLocator.Default;
 
+        serviceLocator.RegisterType<IBaseColorService, BaseColorService>();
         serviceLocator.RegisterType<IFlyoutService, FlyoutService>();
         serviceLocator.RegisterType<IAboutService, MahAppsAboutService>();
         serviceLocator.RegisterType<IMessageService, MahAppsMessageService>();

--- a/src/Orchestra.Shell.MahApps/ModuleInitializer.cs
+++ b/src/Orchestra.Shell.MahApps/ModuleInitializer.cs
@@ -22,7 +22,7 @@ public static partial class ModuleInitializer
     {
         var serviceLocator = ServiceLocator.Default;
 
-        serviceLocator.RegisterType<IBaseColorService, MahAppsBaseColorService>();
+        serviceLocator.RegisterType<IBaseColorSchemeService, MahAppsBaseColorSchemeService>();
         serviceLocator.RegisterType<IFlyoutService, FlyoutService>();
         serviceLocator.RegisterType<IAboutService, MahAppsAboutService>();
         serviceLocator.RegisterType<IMessageService, MahAppsMessageService>();

--- a/src/Orchestra.Shell.MahApps/Services/MahAppsBaseColorService.cs
+++ b/src/Orchestra.Shell.MahApps/Services/MahAppsBaseColorService.cs
@@ -1,0 +1,11 @@
+﻿namespace Orchestra.Services
+{
+    using System.Collections.Generic;
+    public class MahAppsBaseColorService : BaseColorService
+    {
+        public override IReadOnlyList<string> GetAvailableBaseColors()
+        {
+            return new List<string>() { OrchestraEnvironment.DefaultBaseColor, "Dark" }.AsReadOnly();
+        }
+    }
+}

--- a/src/Orchestra.Shell.MahApps/Services/MahAppsBaseColorService.cs
+++ b/src/Orchestra.Shell.MahApps/Services/MahAppsBaseColorService.cs
@@ -1,11 +1,11 @@
 ﻿namespace Orchestra.Services
 {
     using System.Collections.Generic;
-    public class MahAppsBaseColorService : BaseColorService
+    public class MahAppsBaseColorSchemeService : BaseColorSchemeService
     {
-        public override IReadOnlyList<string> GetAvailableBaseColors()
+        public override IReadOnlyList<string> GetAvailableBaseColorSchemes()
         {
-            return new List<string>() { OrchestraEnvironment.DefaultBaseColor, "Dark" }.AsReadOnly();
+            return new List<string>() { OrchestraEnvironment.LightBaseColorScheme, OrchestraEnvironment.DarkBaseColorScheme }.AsReadOnly();
         }
     }
 }

--- a/src/Orchestra.Shell.MahApps/Themes/MahAppsShellTheme.cs
+++ b/src/Orchestra.Shell.MahApps/Themes/MahAppsShellTheme.cs
@@ -16,25 +16,25 @@
 
         private readonly Orc.Controls.Services.IAccentColorService _accentColorService;
         private readonly IThemeService _themeService;
-        private readonly IBaseColorService _baseColorService;
+        private readonly IBaseColorSchemeService _baseColorSchemeService;
 
         public MahAppsShellTheme(Orc.Controls.Services.IAccentColorService accentColorService,            
             IThemeService themeService,
-            IBaseColorService baseColorService)
+            IBaseColorSchemeService baseColorSchemeService)
         {
             Argument.IsNotNull(() => accentColorService);
             Argument.IsNotNull(() => themeService);
-            Argument.IsNotNull(() => baseColorService);
+            Argument.IsNotNull(() => baseColorSchemeService);
 
             _accentColorService = accentColorService;
             _themeService = themeService;
-            _baseColorService = baseColorService;
+            _baseColorSchemeService = baseColorSchemeService;
 
-            _accentColorService.AccentColorChanged += OnAccentBaseColorServiceAccentColorChanged;
-            _baseColorService.BaseColorChanged += OnAccentBaseColorServiceAccentColorChanged;            
+            _accentColorService.AccentColorChanged += OnAccentBaseSchemeColorChanged;
+            _baseColorSchemeService.BaseColorSchemeChanged += OnAccentBaseSchemeColorChanged;            
         }
 
-        private void OnAccentBaseColorServiceAccentColorChanged(object sender, EventArgs e)
+        private void OnAccentBaseSchemeColorChanged(object sender, EventArgs e)
         {
             ApplyTheme(_themeService.GetThemeInfo());
         }

--- a/src/Orchestra.Shell.MahApps/Themes/MahAppsShellTheme.cs
+++ b/src/Orchestra.Shell.MahApps/Themes/MahAppsShellTheme.cs
@@ -16,20 +16,25 @@
 
         private readonly Orc.Controls.Services.IAccentColorService _accentColorService;
         private readonly IThemeService _themeService;
+        private readonly IBaseColorService _baseColorService;
 
-        public MahAppsShellTheme(Orc.Controls.Services.IAccentColorService accentColorService,
-            IThemeService themeService)
+        public MahAppsShellTheme(Orc.Controls.Services.IAccentColorService accentColorService,            
+            IThemeService themeService,
+            IBaseColorService baseColorService)
         {
             Argument.IsNotNull(() => accentColorService);
             Argument.IsNotNull(() => themeService);
+            Argument.IsNotNull(() => baseColorService);
 
             _accentColorService = accentColorService;
             _themeService = themeService;
+            _baseColorService = baseColorService;
 
-            _accentColorService.AccentColorChanged += OnAccentColorServiceAccentColorChanged;
+            _accentColorService.AccentColorChanged += OnAccentBaseColorServiceAccentColorChanged;
+            _baseColorService.BaseColorChanged += OnAccentBaseColorServiceAccentColorChanged;            
         }
 
-        private void OnAccentColorServiceAccentColorChanged(object sender, EventArgs e)
+        private void OnAccentBaseColorServiceAccentColorChanged(object sender, EventArgs e)
         {
             ApplyTheme(_themeService.GetThemeInfo());
         }


### PR DESCRIPTION
### Description of Change ###
`Light` base theme was hard-coded into `ThemeService`, so i added a `BaseColorService` to select base themes

### API Changes ###
- Added `BaseColorService` and integrated it into `ThemeService`

### Platforms Affected ### 
- WPF

### Behavioral Changes ###
None

### Testing Procedure ###
![](https://i.imgur.com/VB1bH08.gif)


### PR Checklist ###

- [x] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
