### PR TITLE
Added basic implementation for configuration backups (CS-191)

### DIFF
--- a/src/Orchestra.Core/ModuleInitializer.cs
+++ b/src/Orchestra.Core/ModuleInitializer.cs
@@ -75,6 +75,7 @@ public static class ModuleInitializer
         serviceLocator.RegisterTypeIfNotYetRegistered<IAboutService, AboutService>();
         serviceLocator.RegisterTypeIfNotYetRegistered<IClipboardService, ClipboardService>();
         serviceLocator.RegisterTypeIfNotYetRegistered<IViewActivationService, ViewActivationService>();
+        serviceLocator.RegisterTypeIfNotYetRegistered<IConfigurationBackupService, ConfigurationBackupService>();
         serviceLocator.RegisterType<IMessageService, Orchestra.Services.MessageService>();
 
         // Theming

--- a/src/Orchestra.Core/Services/ConfigurationBackupService.cs
+++ b/src/Orchestra.Core/Services/ConfigurationBackupService.cs
@@ -69,7 +69,7 @@
 
             Log.Info($"Creating configuration backup, {applicationDataTarget}");
 
-            var configBackupFolderPath = Path.Combine(_appDataService.GetApplicationDataDirectory(Catel.IO.ApplicationDataTarget.UserRoaming), "backup", "config");
+            var configBackupFolderPath = Path.Combine(_appDataService.GetApplicationDataDirectory(applicationDataTarget), "backup", "config");
 
             _directoryService.Create(configBackupFolderPath);
 
@@ -87,7 +87,7 @@
             }
 
             // Save current configuration
-            _fileService.Copy(configurationFilePath, Path.Combine(configBackupFolderPath, $"configuration.{string.Format(BackupTimeStampFormat, DateTime.Now)}.xml"));
+            _fileService.Copy(configurationFilePath, Path.Combine(configBackupFolderPath, $"configuration.{string.Format(BackupTimeStampFormat, DateTime.Now)}.xml"), true);
 
             Log.Info($"Created configuration backup, {applicationDataTarget}");
         }

--- a/src/Orchestra.Core/Services/ConfigurationBackupService.cs
+++ b/src/Orchestra.Core/Services/ConfigurationBackupService.cs
@@ -1,0 +1,112 @@
+﻿namespace Orchestra.Services
+{
+    using System;
+    using System.IO;
+    using System.Linq;
+    using System.Threading.Tasks;
+    using Catel;
+    using Catel.Configuration;
+    using Catel.Logging;
+    using Catel.Reflection;
+    using Catel.Services;
+    using MethodTimer;
+    using Orc.FileSystem;
+
+    public class ConfigurationBackupService : IConfigurationBackupService
+    {
+        private static readonly ILog Log = LogManager.GetCurrentClassLogger();
+        private readonly IConfigurationService _configurationService;
+        private readonly IAppDataService _appDataService;
+        private readonly IFileService _fileService;
+        private readonly IDirectoryService _directoryService;
+
+        public ConfigurationBackupService(IConfigurationService configurationService, IAppDataService appDataService, IFileService fileService, IDirectoryService directoryService)
+        {
+            Argument.IsNotNull(() => configurationService);
+            Argument.IsNotNull(() => appDataService);
+            Argument.IsNotNull(() => fileService);
+            Argument.IsNotNull(() => directoryService);
+
+            _configurationService = configurationService;
+            _appDataService = appDataService;
+            _fileService = fileService;
+            _directoryService = directoryService;
+        }
+
+        public int NumberOfBackups { get; protected set; } = 5;
+
+        public string BackupTimeStampFormat { get; set; } = "{0:yyyyMMdd_HHmmssfff}";
+
+        [Time]
+        public void Backup()
+        {
+            try
+            {
+                // Get configuration paths
+                // Catel.Reflection.ReflectionExtensions.GetFieldEx
+                var roamingConfigFilePathField = _configurationService.GetType().GetFieldEx("_roamingConfigFilePath", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+                var localConfigFilePathField = _configurationService.GetType().GetFieldEx("_localConfigFilePath", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+
+                var roamingConfigFilePath = roamingConfigFilePathField.GetValue(_configurationService).ToString();
+                var localConfigFilePath = localConfigFilePathField.GetValue(_configurationService).ToString();
+
+                if (_fileService.Exists(roamingConfigFilePath))
+                {
+                    BackupConfiguration(roamingConfigFilePath, Catel.IO.ApplicationDataTarget.UserRoaming);
+                }
+                else
+                {
+                    Log.Info($"Configuration file not found on path {roamingConfigFilePath}, skipping backup");
+                }
+                if (_fileService.Exists(localConfigFilePath))
+                {
+                    BackupConfiguration(localConfigFilePath, Catel.IO.ApplicationDataTarget.UserLocal);
+                }
+                else
+                {
+                    Log.Info($"Configuration file not found on path {roamingConfigFilePath}, skipping backup");
+                }
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Failed to create database backup");
+                throw;
+            }
+        }
+
+        private void BackupConfiguration(string configurationFilePath, Catel.IO.ApplicationDataTarget applicationDataTarget)
+        {
+            Log.Info($"Creating configuration backup, {applicationDataTarget}");
+
+            var configBackupFolderPath = Path.Combine(_appDataService.GetApplicationDataDirectory(Catel.IO.ApplicationDataTarget.UserRoaming), "backup\\config\\");
+            if (!_directoryService.Exists(configBackupFolderPath))
+            {
+                _directoryService.Create(configBackupFolderPath);
+            }
+
+            var backupConfigurationFiles = _directoryService.GetFiles(configBackupFolderPath, "configuration*").OrderBy(f => f).ToList();
+            if (backupConfigurationFiles.Count >= NumberOfBackups)
+            {
+                // Remove oldest backup
+                var filesToRemoveCount = 1 + NumberOfBackups - backupConfigurationFiles.Count;
+
+                for (int i = 0; i < filesToRemoveCount; i++)
+                {
+                    var backupFilePath = Path.Combine(configBackupFolderPath, backupConfigurationFiles[i]);
+                    _fileService.Delete(backupFilePath);
+                }
+            }
+
+            // Save current configuration
+            _fileService.Copy(configurationFilePath, Path.Combine(configBackupFolderPath, $"configuration.{string.Format(BackupTimeStampFormat, DateTime.Now)}.xml"));
+
+            Log.Info($"Created configration backup, {applicationDataTarget}");
+        }
+
+        [Time]
+        public async Task BackupAsync()
+        {
+            Backup();
+        }
+    }
+}

--- a/src/Orchestra.Core/Services/Interfaces/IConfigurationBackupService.cs
+++ b/src/Orchestra.Core/Services/Interfaces/IConfigurationBackupService.cs
@@ -1,0 +1,11 @@
+﻿namespace Orchestra.Services
+{
+    using System.Threading.Tasks;
+    using MethodTimer;
+
+    public interface IConfigurationBackupService
+    {
+        void Backup();
+        Task BackupAsync();
+    }
+}

--- a/src/Orchestra.Core/Services/Interfaces/IConfigurationBackupService.cs
+++ b/src/Orchestra.Core/Services/Interfaces/IConfigurationBackupService.cs
@@ -7,7 +7,6 @@
         string BackupTimeStampFormat { get; set; }
         int NumberOfBackups { get; }
 
-        void Backup();
         Task BackupAsync();
     }
 }

--- a/src/Orchestra.Core/Services/Interfaces/IConfigurationBackupService.cs
+++ b/src/Orchestra.Core/Services/Interfaces/IConfigurationBackupService.cs
@@ -1,10 +1,12 @@
 ﻿namespace Orchestra.Services
 {
     using System.Threading.Tasks;
-    using MethodTimer;
 
     public interface IConfigurationBackupService
     {
+        string BackupTimeStampFormat { get; set; }
+        int NumberOfBackups { get; }
+
         void Backup();
         Task BackupAsync();
     }

--- a/src/Orchestra.Shell.Shared/Services/ShellService.cs
+++ b/src/Orchestra.Shell.Shared/Services/ShellService.cs
@@ -163,6 +163,9 @@ namespace Orchestra.Services
 
             await _ensureStartupService.EnsureFailSafeStartupAsync();
 
+            // Maintaining backups
+            await _configurationBackupService.BackupAsync();
+
             var shell = default(TShell);
             var successfullyStarted = true;
 
@@ -220,9 +223,6 @@ namespace Orchestra.Services
         private async Task InitializeBeforeCreatingShellAsync()
         {
             Log.Debug("Calling IApplicationInitializationService.InitializeBeforeCreatingShell");
-
-            // Maintaining backups
-            await _configurationBackupService.BackupAsync();
 
             await _applicationInitializationService.InitializeBeforeCreatingShellAsync();
         }

--- a/src/Orchestra.Shell.Shared/Services/ShellService.cs
+++ b/src/Orchestra.Shell.Shared/Services/ShellService.cs
@@ -37,6 +37,7 @@ namespace Orchestra.Services
         private readonly IApplicationInitializationService _applicationInitializationService;
         private readonly IDependencyResolver _dependencyResolver;
         private readonly IServiceLocator _serviceLocator;
+        private readonly IConfigurationBackupService _configurationBackupService;
         #endregion
 
         #region Constructors
@@ -51,6 +52,7 @@ namespace Orchestra.Services
         /// <param name="applicationInitializationService">The application initialization service.</param>
         /// <param name="dependencyResolver">The dependency resolver.</param>
         /// <param name="serviceLocator">The service locator.</param>
+        /// <param name="configurationBackupService">The configuration backup service</param>
         /// <exception cref="ArgumentNullException">The <paramref name="typeFactory" /> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="keyboardMappingsService" /> is <c>null</c>.</exception>
         /// <exception cref="ArgumentNullException">The <paramref name="commandManager" /> is <c>null</c>.</exception>
@@ -61,7 +63,7 @@ namespace Orchestra.Services
         public ShellService(ITypeFactory typeFactory, IKeyboardMappingsService keyboardMappingsService, ICommandManager commandManager,
             ISplashScreenService splashScreenService, IEnsureStartupService ensureStartupService, 
             IApplicationInitializationService applicationInitializationService, IDependencyResolver dependencyResolver,
-            IServiceLocator serviceLocator)
+            IServiceLocator serviceLocator, IConfigurationBackupService configurationBackupService)
         {
             Argument.IsNotNull(() => typeFactory);
             Argument.IsNotNull(() => keyboardMappingsService);
@@ -71,6 +73,7 @@ namespace Orchestra.Services
             Argument.IsNotNull(() => applicationInitializationService);
             Argument.IsNotNull(() => dependencyResolver);
             Argument.IsNotNull(() => serviceLocator);
+            Argument.IsNotNull(() => configurationBackupService);
 
             _typeFactory = typeFactory;
             _keyboardMappingsService = keyboardMappingsService;
@@ -80,6 +83,7 @@ namespace Orchestra.Services
             _applicationInitializationService = applicationInitializationService;
             _dependencyResolver = dependencyResolver;
             _serviceLocator = serviceLocator;
+            _configurationBackupService = configurationBackupService;
 
             var entryAssembly = Catel.Reflection.AssemblyHelper.GetEntryAssembly();
 
@@ -216,6 +220,9 @@ namespace Orchestra.Services
         private async Task InitializeBeforeCreatingShellAsync()
         {
             Log.Debug("Calling IApplicationInitializationService.InitializeBeforeCreatingShell");
+
+            // Maintaining backups
+            await _configurationBackupService.BackupAsync();
 
             await _applicationInitializationService.InitializeBeforeCreatingShellAsync();
         }

--- a/src/Orchestra.Tests/Orchestra.Core.approved.cs
+++ b/src/Orchestra.Tests/Orchestra.Core.approved.cs
@@ -1186,15 +1186,3 @@ namespace Orchestra.Windows
         public static void ApplyApplicationIcon(this System.Windows.Window window) { }
     }
 }
-namespace XamlGeneratedNamespace
-{
-    public sealed class GeneratedInternalTypeHelper : System.Windows.Markup.InternalTypeHelper
-    {
-        public GeneratedInternalTypeHelper() { }
-        protected override void AddEventHandler(System.Reflection.EventInfo eventInfo, object target, System.Delegate handler) { }
-        protected override System.Delegate CreateDelegate(System.Type delegateType, object target, string handler) { }
-        protected override object CreateInstance(System.Type type, System.Globalization.CultureInfo culture) { }
-        protected override object GetPropertyValue(System.Reflection.PropertyInfo propertyInfo, object target, System.Globalization.CultureInfo culture) { }
-        protected override void SetPropertyValue(System.Reflection.PropertyInfo propertyInfo, object target, object value, System.Globalization.CultureInfo culture) { }
-    }
-}

--- a/src/Orchestra.Tests/Orchestra.Core.approved.cs
+++ b/src/Orchestra.Tests/Orchestra.Core.approved.cs
@@ -599,6 +599,14 @@ namespace Orchestra.Services
         public void Invalidate() { }
         public void UpdateCommandInfo(string commandName, Orchestra.Models.ICommandInfo commandInfo) { }
     }
+    public class ConfigurationBackupService : Orchestra.Services.IConfigurationBackupService
+    {
+        public ConfigurationBackupService(Catel.Configuration.IConfigurationService configurationService, Catel.Services.IAppDataService appDataService, Orc.FileSystem.IFileService fileService, Orc.FileSystem.IDirectoryService directoryService) { }
+        public string BackupTimeStampFormat { get; set; }
+        public int NumberOfBackups { get; set; }
+        public virtual System.Threading.Tasks.Task BackupAsync() { }
+        protected virtual System.Threading.Tasks.Task BackupConfigurationAsync(string configurationFilePath, Catel.IO.ApplicationDataTarget applicationDataTarget) { }
+    }
     public class EnsureStartupService : Orchestra.Services.IEnsureStartupService
     {
         public EnsureStartupService(Catel.Services.IAppDataService appDataService, Catel.Services.IUIVisualizerService uiVisualizerService, Orc.FileSystem.IFileService fileService) { }
@@ -656,6 +664,12 @@ namespace Orchestra.Services
     public static class ICommandInfoServiceExtensions
     {
         public static void UpdateCommandInfo(this Orchestra.Services.ICommandInfoService commandInfoService, string commandName, System.Action<Orchestra.Models.ICommandInfo> commandInfoUpdateCallback) { }
+    }
+    public interface IConfigurationBackupService
+    {
+        string BackupTimeStampFormat { get; set; }
+        int NumberOfBackups { get; }
+        System.Threading.Tasks.Task BackupAsync();
     }
     public interface IEnsureStartupService
     {
@@ -1170,5 +1184,17 @@ namespace Orchestra.Windows
     public static class WindowExtensions
     {
         public static void ApplyApplicationIcon(this System.Windows.Window window) { }
+    }
+}
+namespace XamlGeneratedNamespace
+{
+    public sealed class GeneratedInternalTypeHelper : System.Windows.Markup.InternalTypeHelper
+    {
+        public GeneratedInternalTypeHelper() { }
+        protected override void AddEventHandler(System.Reflection.EventInfo eventInfo, object target, System.Delegate handler) { }
+        protected override System.Delegate CreateDelegate(System.Type delegateType, object target, string handler) { }
+        protected override object CreateInstance(System.Type type, System.Globalization.CultureInfo culture) { }
+        protected override object GetPropertyValue(System.Reflection.PropertyInfo propertyInfo, object target, System.Globalization.CultureInfo culture) { }
+        protected override void SetPropertyValue(System.Reflection.PropertyInfo propertyInfo, object target, object value, System.Globalization.CultureInfo culture) { }
     }
 }

--- a/src/Orchestra.Tests/Orchestra.Shell.MahApps.approved.cs
+++ b/src/Orchestra.Tests/Orchestra.Shell.MahApps.approved.cs
@@ -119,7 +119,7 @@ namespace Orchestra.Services
     }
     public class ShellService : Orchestra.Services.IShellService
     {
-        public ShellService(Catel.IoC.ITypeFactory typeFactory, Orchestra.Services.IKeyboardMappingsService keyboardMappingsService, Catel.MVVM.ICommandManager commandManager, Orchestra.Services.ISplashScreenService splashScreenService, Orchestra.Services.IEnsureStartupService ensureStartupService, Orchestra.Services.IApplicationInitializationService applicationInitializationService, Catel.IoC.IDependencyResolver dependencyResolver, Catel.IoC.IServiceLocator serviceLocator) { }
+        public ShellService(Catel.IoC.ITypeFactory typeFactory, Orchestra.Services.IKeyboardMappingsService keyboardMappingsService, Catel.MVVM.ICommandManager commandManager, Orchestra.Services.ISplashScreenService splashScreenService, Orchestra.Services.IEnsureStartupService ensureStartupService, Orchestra.Services.IApplicationInitializationService applicationInitializationService, Catel.IoC.IDependencyResolver dependencyResolver, Catel.IoC.IServiceLocator serviceLocator, Orchestra.Services.IConfigurationBackupService configurationBackupService) { }
         public Orchestra.Views.IShell Shell { get; }
         public System.Threading.Tasks.Task<TShell> CreateAsync<TShell>()
             where TShell :  class, Orchestra.Views.IShell { }

--- a/src/Orchestra.Tests/Orchestra.Shell.Ribbon.Fluent.approved.cs
+++ b/src/Orchestra.Tests/Orchestra.Shell.Ribbon.Fluent.approved.cs
@@ -108,7 +108,7 @@ namespace Orchestra.Services
     }
     public class ShellService : Orchestra.Services.IShellService
     {
-        public ShellService(Catel.IoC.ITypeFactory typeFactory, Orchestra.Services.IKeyboardMappingsService keyboardMappingsService, Catel.MVVM.ICommandManager commandManager, Orchestra.Services.ISplashScreenService splashScreenService, Orchestra.Services.IEnsureStartupService ensureStartupService, Orchestra.Services.IApplicationInitializationService applicationInitializationService, Catel.IoC.IDependencyResolver dependencyResolver, Catel.IoC.IServiceLocator serviceLocator) { }
+        public ShellService(Catel.IoC.ITypeFactory typeFactory, Orchestra.Services.IKeyboardMappingsService keyboardMappingsService, Catel.MVVM.ICommandManager commandManager, Orchestra.Services.ISplashScreenService splashScreenService, Orchestra.Services.IEnsureStartupService ensureStartupService, Orchestra.Services.IApplicationInitializationService applicationInitializationService, Catel.IoC.IDependencyResolver dependencyResolver, Catel.IoC.IServiceLocator serviceLocator, Orchestra.Services.IConfigurationBackupService configurationBackupService) { }
         public Orchestra.Views.IShell Shell { get; }
         public System.Threading.Tasks.Task<TShell> CreateAsync<TShell>()
             where TShell :  class, Orchestra.Views.IShell { }

--- a/src/Orchestra.Tests/Services/ConfigurationBackupServiceFacts.cs
+++ b/src/Orchestra.Tests/Services/ConfigurationBackupServiceFacts.cs
@@ -1,0 +1,79 @@
+﻿namespace Orchestra.Tests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+    using Catel.Configuration;
+    using Catel.IO;
+    using Catel.IoC;
+    using Catel.Services;
+    using NUnit.Framework;
+    using Orc.FileSystem;
+    using Orchestra.Services;
+
+    [TestFixture]
+    public class ConfigurationBackupServiceFacts
+    {
+        private TestConfigurationBackupService _testConfigurationBackupService = null;
+       
+        [TestCase(
+            @"C:\Users\JustAnotherUser\AppData\Roaming\WildGums\Orchestra.Examples.Ribbon.Fluent\testconfiguration.xml",
+            @"C:\Users\JustAnotherUser\AppData\Local\WildGums\Orchestra.Examples.Ribbon.Fluent\testconfiguration.xml",
+            15
+        )]
+        public async Task TestBackupConfigurationAsyncCleanupExpectedAsync(string roamingConfigPath, string localConfigPath, int numberOfRuns)
+        {
+            var sl = ServiceLocator.Default;
+            var configurationService = sl.ResolveType<IConfigurationService>();
+            var appDataService = sl.ResolveType<IAppDataService>();
+            var fileService = sl.ResolveType<IFileService>();
+            var directoryService = sl.ResolveType<IDirectoryService>();
+
+            // Pre-initialization
+            if (_testConfigurationBackupService is null)
+            {
+                _testConfigurationBackupService = new TestConfigurationBackupService(configurationService, appDataService, fileService, directoryService);
+            }
+
+            // Prepare files for case
+            using (fileService.Create(roamingConfigPath))
+            using (fileService.Create(localConfigPath))
+            { 
+            }
+
+            // Testing case
+            for (int i = 0; i < numberOfRuns; i++)
+            {
+                await _testConfigurationBackupService.TestBackupConfigurationAsync(roamingConfigPath, ApplicationDataTarget.UserRoaming);
+                await _testConfigurationBackupService.TestBackupConfigurationAsync(localConfigPath, ApplicationDataTarget.UserLocal);
+            }
+
+            // Check file count
+            var countInRoaming = directoryService.GetFiles(@"C:\Users\JustAnotherUser\AppData\Roaming\Microsoft Corporation\Microsoft.TestHost\backup\config", "configuration*").Count();
+            var countInLocal = directoryService.GetFiles(@"C:\Users\JustAnotherUser\AppData\Local\Microsoft Corporation\Microsoft.TestHost\backup\config", "configuration*").Count();
+
+            Assert.AreEqual(countInRoaming, _testConfigurationBackupService.NumberOfBackups);
+            Assert.AreEqual(countInLocal, _testConfigurationBackupService.NumberOfBackups);
+        }
+
+        public class TestConfigurationBackupService : ConfigurationBackupService
+        {
+            public TestConfigurationBackupService(IConfigurationService configurationService, IAppDataService appDataService, IFileService fileService, IDirectoryService directoryService)
+                : base(configurationService, appDataService, fileService, directoryService)
+            {
+            }
+
+            public async Task TestBackupConfigurationAsync(string configurationFilePath, ApplicationDataTarget applicationDataTarget)
+            {
+                await BackupConfigurationAsync(configurationFilePath, applicationDataTarget);
+            }
+
+            protected override async Task BackupConfigurationAsync(string configurationFilePath, ApplicationDataTarget applicationDataTarget)
+            {
+                await base.BackupConfigurationAsync(configurationFilePath, applicationDataTarget);
+            }
+        }
+    }
+}

--- a/src/Orchestra.Tests/Services/ConfigurationBackupServiceFacts.cs
+++ b/src/Orchestra.Tests/Services/ConfigurationBackupServiceFacts.cs
@@ -19,8 +19,8 @@
         private TestConfigurationBackupService _testConfigurationBackupService = null;
        
         [TestCase(
-            @"C:\Users\JustAnotherUser\AppData\Roaming\WildGums\Orchestra.Examples.Ribbon.Fluent\testconfiguration.xml",
-            @"C:\Users\JustAnotherUser\AppData\Local\WildGums\Orchestra.Examples.Ribbon.Fluent\testconfiguration.xml",
+            @"C:\Users\{0}\AppData\Roaming\WildGums\Orchestra.Examples.Ribbon.Fluent\testconfiguration.xml",
+            @"C:\Users\{0}\AppData\Local\WildGums\Orchestra.Examples.Ribbon.Fluent\testconfiguration.xml",
             15
         )]
         public async Task TestBackupConfigurationAsyncCleanupExpectedAsync(string roamingConfigPath, string localConfigPath, int numberOfRuns)
@@ -31,6 +31,10 @@
             var fileService = sl.ResolveType<IFileService>();
             var directoryService = sl.ResolveType<IDirectoryService>();
 
+            // Initialize paths
+            roamingConfigPath = string.Format(roamingConfigPath, Environment.UserName);
+            localConfigPath = string.Format(localConfigPath, Environment.UserName);
+
             // Pre-initialization
             if (_testConfigurationBackupService is null)
             {
@@ -39,6 +43,9 @@
 
             // Prepare files for case
             using (fileService.Create(roamingConfigPath))
+            {
+
+            }
             using (fileService.Create(localConfigPath))
             { 
             }
@@ -51,8 +58,10 @@
             }
 
             // Check file count
-            var countInRoaming = directoryService.GetFiles(@"C:\Users\JustAnotherUser\AppData\Roaming\Microsoft Corporation\Microsoft.TestHost\backup\config", "configuration*").Count();
-            var countInLocal = directoryService.GetFiles(@"C:\Users\JustAnotherUser\AppData\Local\Microsoft Corporation\Microsoft.TestHost\backup\config", "configuration*").Count();
+            var countInRoaming = directoryService.GetFiles(string.Format(@"C:\Users\{0}\AppData\Roaming\Microsoft Corporation\Microsoft.TestHost\backup\config", Environment.UserName),
+                "configuration*").Count();
+            var countInLocal = directoryService.GetFiles(string.Format(@"C:\Users\{0}\AppData\Local\Microsoft Corporation\Microsoft.TestHost\backup\config", Environment.UserName),
+                "configuration*").Count();
 
             Assert.AreEqual(countInRoaming, _testConfigurationBackupService.NumberOfBackups);
             Assert.AreEqual(countInLocal, _testConfigurationBackupService.NumberOfBackups);


### PR DESCRIPTION
### Description of Change ###
This feature add simple backup for configuration files. It's known issue in certain cases configuration can reset when multiple instances of shell launched. This one implementation allows at least keep and turn back user information.

The default value for number of store backups is **5**
The service do own work before shell shown.
### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes CS-191 (related)

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
Orchestra.Core

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- All


### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
