### PR TITLE
Extend CloseApplicationWatcherBase

### DIFF
--- a/src/Orchestra.Core/ApplicationWatchers/ApplicationWatcherBase.cs
+++ b/src/Orchestra.Core/ApplicationWatchers/ApplicationWatcherBase.cs
@@ -62,6 +62,12 @@
         {
             DispatcherTimer.Stop();
 
+            if (Application.Current is null)
+            {
+                // Compatibility with no shell (unit tests, different platforms)
+                return;
+            }
+
             var mainWindow = System.Windows.Application.Current.MainWindow;
             if (mainWindow is Orchestra.Views.SplashScreen || SplashScreenViewModel.IsActive)
             {

--- a/src/Orchestra.Core/ApplicationWatchers/ApplicationWatcherBase.cs
+++ b/src/Orchestra.Core/ApplicationWatchers/ApplicationWatcherBase.cs
@@ -62,9 +62,9 @@
         {
             DispatcherTimer.Stop();
 
-            if (Application.Current is null)
+            if (NoShell())
             {
-                // Compatibility with no shell (unit tests, different platforms)
+                // Important for unit test compatibility
                 return;
             }
 
@@ -102,6 +102,11 @@
                     }
                 }
             }
+        }
+
+        private static bool NoShell()
+        {
+            return Application.Current is null;
         }
     }
 }

--- a/src/Orchestra.Core/ApplicationWatchers/CloseApplicationWatcherBase.cs
+++ b/src/Orchestra.Core/ApplicationWatchers/CloseApplicationWatcherBase.cs
@@ -38,7 +38,7 @@
         {
             var lastWatcher = Watchers.LastOrDefault();
             Watchers.Clear();
-            
+
             if (lastWatcher is not null)
             {
                 Watchers.Add(lastWatcher);
@@ -106,7 +106,7 @@
 
             Log.Debug("Perform closed operations after closing confirmed");
 
-            await PerformClosedOperationAsync();
+            await PerformClosedOperationsAsync();
 
             // Fully done, now really close
             CanClose = true;
@@ -154,9 +154,10 @@
             }
         }
 
-        private static async Task PerformClosedOperationAsync()
+        private static async Task PerformClosedOperationsAsync()
         {
             await ExecuteClosedAsync(ClosedAsync);
+
         }
 
         private static async Task<bool> PrepareClosingAsync(CloseApplicationWatcherBase watcher)
@@ -171,8 +172,8 @@
             }
             catch (Exception ex)
             {
-                Log.Error(ex, $"Failed to execute PrepareClosingAsync() for '{ObjectToStringHelper.ToFullTypeString(watcher)}'");
-                throw;
+                Log.Error(ex, $"Failed to execute PrepareClosingAsync() for '{ObjectToStringHelper.ToFullTypeString(watcher)}'. Continue to run all watchers left.");
+                return true;
             }
         }
 
@@ -188,8 +189,8 @@
             }
             catch (Exception ex)
             {
-                Log.Error(ex, $"Failed to execute ClosingAsync() for '{ObjectToStringHelper.ToFullTypeString(watcher)}'");
-                throw;
+                Log.Error(ex, $"Failed to execute ClosingAsync() for '{ObjectToStringHelper.ToFullTypeString(watcher)}'. Continue to run all watchers left.");
+                return true;
             }
         }
 
@@ -202,8 +203,7 @@
             }
             catch (Exception ex)
             {
-                Log.Error(ex, $"Failed to execute ClosedAsync() for '{ObjectToStringHelper.ToFullTypeString(watcher)}'");
-                throw;
+                Log.Error(ex, $"Failed to execute ClosedAsync() for '{ObjectToStringHelper.ToFullTypeString(watcher)}'. Continue to run all watchers left.");
             }
         }
 
@@ -281,14 +281,7 @@
 
             foreach (var watcher in Watchers)
             {
-                try
-                {
-                    await operation(watcher);
-                }
-                catch (Exception)
-                {
-                    // Never break on a single watcher
-                }
+                await operation(watcher);
             }
         }
 

--- a/src/Orchestra.Core/ApplicationWatchers/CloseApplicationWatcherBase.cs
+++ b/src/Orchestra.Core/ApplicationWatchers/CloseApplicationWatcherBase.cs
@@ -3,6 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.ComponentModel;
+    using System.Linq;
     using System.Threading.Tasks;
     using System.Windows;
     using Catel;
@@ -28,6 +29,24 @@
             Watchers.Add(this);
 
             EnqueueShellActivatedAction(Subscribe);
+        }
+
+        /// <summary>
+        /// Only used to reset the state for unit tests.
+        /// </summary>
+        protected internal static void Reset()
+        {
+            var lastWatcher = Watchers.LastOrDefault();
+            Watchers.Clear();
+            
+            if (lastWatcher is not null)
+            {
+                Watchers.Add(lastWatcher);
+            }
+
+            IsClosingConfirmed = false;
+            IsHandlingClosing = false;
+            CanClose = false;
         }
 
 #pragma warning disable AvoidAsyncVoid

--- a/src/Orchestra.Core/ApplicationWatchers/CloseApplicationWatcherBase.cs
+++ b/src/Orchestra.Core/ApplicationWatchers/CloseApplicationWatcherBase.cs
@@ -61,20 +61,11 @@
                 return;
             }
 
-            // Clone event args
-            var clonedEventArgs = new CancelEventArgs();
-
             try
             {
                 IsHandlingClosing = true;
 
                 Log.Debug("Closing main window");
-
-                if (clonedEventArgs.Cancel)
-                {
-                    Log.Debug("Closing is cancelled");
-                    return;
-                }
 
                 if (!IsClosingConfirmed)
                 {
@@ -88,7 +79,7 @@
                 IsHandlingClosing = false;
             }
 
-            if (clonedEventArgs.Cancel)
+            if (!IsClosingConfirmed)
             {
                 Log.Debug("At least 1 watcher requested canceling the closing of the window");
                 return;
@@ -258,8 +249,6 @@
             {
                 if (!await operation(watcher).ConfigureAwait(false))
                 {
-                    NotifyClosingCanceled();
-
                     return false;
                 }
             }

--- a/src/Orchestra.Core/ApplicationWatchers/CloseApplicationWatcherBase.cs
+++ b/src/Orchestra.Core/ApplicationWatchers/CloseApplicationWatcherBase.cs
@@ -69,10 +69,6 @@
             {
                 ExecuteClosed(Closed);
             }
-            catch (TaskCanceledException)
-            {
-                // Ignore, don't log
-            }
             catch (Exception ex)
             {
                 Log.Error(ex, "Failed to perform closed operations");

--- a/src/Orchestra.Core/ApplicationWatchers/CloseApplicationWatcherBase.cs
+++ b/src/Orchestra.Core/ApplicationWatchers/CloseApplicationWatcherBase.cs
@@ -102,7 +102,7 @@
             CanClose = true;
 
             // Close window (again, we will not interfere this time)
-            await DispatcherService.InvokeAsync(window.Close).ConfigureAwait(false);
+            await CloseWindowAsync(window).ConfigureAwait(false);
         }
 
         private static async Task PerformClosingOperationsAsync(Window window)
@@ -123,13 +123,11 @@
                 IsClosingConfirmed = await ExecuteClosingAsync(ClosingAsync).ConfigureAwait(false);
                 if (IsClosingConfirmed)
                 {
-                    Log.Debug("Closing confirmed, request closing again");
-
-                    await CloseWindowAsync(window).ConfigureAwait(false);
+                    Log.Debug("Closing confirmed, continue execution");
                 }
                 else
                 {
-                    Log.Debug("Closing cancelled, request closing again");
+                    Log.Debug("Closing cancelled, raising notification");
 
                     NotifyClosingCanceled();
                 }
@@ -241,8 +239,7 @@
 
         private static async Task CloseWindowAsync(Window window)
         {
-            IsClosingConfirmed = true;
-            // await DispatcherService.InvokeAsync(window.Close).ConfigureAwait(false);
+            await DispatcherService.InvokeAsync(window.Close).ConfigureAwait(false);
         }
 
         private static void NotifyClosingCanceled()

--- a/src/Orchestra.Core/ApplicationWatchers/CloseApplicationWatcherBase.cs
+++ b/src/Orchestra.Core/ApplicationWatchers/CloseApplicationWatcherBase.cs
@@ -55,7 +55,7 @@
             }
         }
 
-        private static async void OnWindowClosed(object sender, EventArgs e)
+        private static void OnWindowClosed(object sender, EventArgs e)
         {
             Log.Debug("Main window closed");
 
@@ -67,7 +67,7 @@
 
             try
             {
-                await ExecuteClosedAsync(ClosedAsync);
+                ExecuteClosed(Closed);
             }
             catch (TaskCanceledException)
             {
@@ -154,12 +154,12 @@
             }
         }
 
-        private static async Task ClosedAsync(CloseApplicationWatcherBase watcher)
+        private static void Closed(CloseApplicationWatcherBase watcher)
         {
             try
             {
                 Log.Debug($"Executing ClosedAsync() for '{ObjectToStringHelper.ToFullTypeString(watcher)}'");
-                await watcher.ClosedAsync();
+                watcher.Closed();
             }
             catch (Exception ex)
             {
@@ -240,13 +240,13 @@
             return true;
         }
 
-        private static async Task ExecuteClosedAsync(Func<CloseApplicationWatcherBase, Task> operation)
+        private static void ExecuteClosed(Action<CloseApplicationWatcherBase> operation)
         {
             Log.Debug($"Execute operation for each of {Watchers.Count} watcher");
 
             foreach (var watcher in Watchers)
             {
-                await operation(watcher).ConfigureAwait(false);
+                operation(watcher);
             }
         }
 
@@ -270,9 +270,9 @@
             return TaskHelper<bool>.FromResult(true);
         }
 
-        protected virtual Task ClosedAsync()
+        protected virtual void Closed()
         {
-            return TaskHelper.Completed;
+
         }
 
         private static void Subscribe(Window window)

--- a/src/Orchestra.Examples.Ribbon.Fluent/Services/ApplicationInitializationService.cs
+++ b/src/Orchestra.Examples.Ribbon.Fluent/Services/ApplicationInitializationService.cs
@@ -91,6 +91,7 @@ namespace Orchestra.Examples.Ribbon.Services
             var serviceLocator = _serviceLocator;
 
             serviceLocator.RegisterType<IAboutInfoService, AboutInfoService>();
+            serviceLocator.RegisterTypeAndInstantiate<UserMessageCloseApplicationWatcher>();
 
             //throw new Exception("this is a test exception");
         }

--- a/src/Orchestra.Examples.Ribbon.Fluent/Services/UserMessageCloseApplicationWatcher.cs
+++ b/src/Orchestra.Examples.Ribbon.Fluent/Services/UserMessageCloseApplicationWatcher.cs
@@ -1,0 +1,24 @@
+﻿namespace Orchestra.Examples.Ribbon.Services
+{
+    using System.Threading.Tasks;
+    using Catel;
+    using Catel.Services;
+
+    internal class UserMessageCloseApplicationWatcher : CloseApplicationWatcherBase
+    {
+        private readonly IMessageService _messageService;
+
+        public UserMessageCloseApplicationWatcher(IMessageService messageService)
+        {
+            Argument.IsNotNull(() => messageService);
+
+            _messageService = messageService;
+        }
+
+        protected override async Task<bool> ClosingAsync()
+        {
+            var result = await _messageService.ShowAsync("Are you sure you want to close example?", "Closing", MessageButton.OKCancel, MessageImage.Question);
+            return result == MessageResult.Yes;
+        }
+    }
+}

--- a/src/Orchestra.Examples.Ribbon.Fluent/Services/UserMessageCloseApplicationWatcher.cs
+++ b/src/Orchestra.Examples.Ribbon.Fluent/Services/UserMessageCloseApplicationWatcher.cs
@@ -1,24 +1,40 @@
 ﻿namespace Orchestra.Examples.Ribbon.Services
 {
+    using System;
     using System.Threading.Tasks;
     using Catel;
     using Catel.Services;
+    using Orc.Notifications;
 
     internal class UserMessageCloseApplicationWatcher : CloseApplicationWatcherBase
     {
         private readonly IMessageService _messageService;
+        private readonly INotificationService _notificationService;
 
-        public UserMessageCloseApplicationWatcher(IMessageService messageService)
+        public UserMessageCloseApplicationWatcher(IMessageService messageService, INotificationService notificationService)
         {
             Argument.IsNotNull(() => messageService);
+            Argument.IsNotNull(() => notificationService);
 
             _messageService = messageService;
+            _notificationService = notificationService;
         }
 
         protected override async Task<bool> ClosingAsync()
         {
-            var result = await _messageService.ShowAsync("Are you sure you want to close example?", "Closing", MessageButton.OKCancel, MessageImage.Question);
+            var result = await _messageService.ShowAsync("Are you sure you want to close example?", "Closing", MessageButton.YesNo, MessageImage.Question);
             return result == MessageResult.Yes;
+        }
+
+        protected override async Task ClosedAsync()
+        {
+            _notificationService.ShowNotification(new Notification
+            {
+                Title = "Closing approved",
+                Message = "User approved closing the app, closing within 5 seconds",
+            });
+
+            await Task.Delay(TimeSpan.FromSeconds(5));
         }
     }
 }

--- a/src/Orchestra.Tests/Orchestra.Core.approved.cs
+++ b/src/Orchestra.Tests/Orchestra.Core.approved.cs
@@ -33,7 +33,7 @@ namespace Orchestra
     public abstract class CloseApplicationWatcherBase : Orchestra.ApplicationWatcherBase
     {
         protected CloseApplicationWatcherBase() { }
-        protected virtual void Closed() { }
+        protected virtual System.Threading.Tasks.Task ClosedAsync() { }
         protected virtual System.Threading.Tasks.Task<bool> ClosingAsync() { }
         protected virtual void ClosingCanceled() { }
         protected virtual void ClosingFailed(Orchestra.ClosingDetails appClosingFaultDetails) { }

--- a/src/Orchestra.Tests/Orchestra.Core.approved.cs
+++ b/src/Orchestra.Tests/Orchestra.Core.approved.cs
@@ -33,6 +33,7 @@ namespace Orchestra
     public abstract class CloseApplicationWatcherBase : Orchestra.ApplicationWatcherBase
     {
         protected CloseApplicationWatcherBase() { }
+        protected virtual void Closed() { }
         protected virtual System.Threading.Tasks.Task<bool> ClosingAsync() { }
         protected virtual void ClosingCanceled() { }
         protected virtual void ClosingFailed(Orchestra.ClosingDetails appClosingFaultDetails) { }

--- a/src/Orchestra.Tests/Orchestra.Core.approved.cs
+++ b/src/Orchestra.Tests/Orchestra.Core.approved.cs
@@ -38,6 +38,7 @@ namespace Orchestra
         protected virtual void ClosingCanceled() { }
         protected virtual void ClosingFailed(Orchestra.ClosingDetails appClosingFaultDetails) { }
         protected virtual System.Threading.Tasks.Task<bool> PrepareClosingAsync() { }
+        protected static void Reset() { }
     }
     public class ClosingDetails
     {

--- a/src/Orchestra.Tests/Services/CloseApplicationWatcherBaseFacts.cs
+++ b/src/Orchestra.Tests/Services/CloseApplicationWatcherBaseFacts.cs
@@ -5,20 +5,41 @@
     using System.Reflection;
     using System.Threading;
     using System.Threading.Tasks;
+    using Catel;
     using NUnit.Framework;
 
     [TestFixture]
     public class CloseApplicationWatcherBaseFacts
     {
+        private const int OnWindowClosingWaitingTimeout = 5000;
+
         [TestCase]
         public async Task Verify_Closing_Allows_Cancel_When_Returning_False_Async()
         {
-            bool isWatcherCompleted = false;
-            using (var cts = new CancellationTokenSource(5000))
-            {
-                // tested object
-                var watcher = new TestCloseApplicationWatcher(true);
+            var watcher = new TestCloseApplicationWatcher(true);
+            await RunOnWindowClosingAndWaitForFinishAsync(watcher, OnWindowClosingWaitingTimeout);
 
+            Assert.IsTrue(watcher.IsClosingRun, "Closing did not run");
+            Assert.IsFalse(watcher.IsClosedRun, "Closed did run");
+        }
+
+        [TestCase]
+        public async Task Verify_Closing_Closed_Operations_Are_Executing_Async()
+        {
+            var watcher = new TestCloseApplicationWatcher(false);
+            await RunOnWindowClosingAndWaitForFinishAsync(watcher, OnWindowClosingWaitingTimeout);
+
+            Assert.IsTrue(watcher.IsClosingRun, "Closing did not run");
+            Assert.IsTrue(watcher.IsClosedRun, "Closed did not run");
+        }
+
+        private async Task RunOnWindowClosingAndWaitForFinishAsync(TestCloseApplicationWatcher watcher, int timeout)
+        {
+            Argument.IsNotNull(() => watcher);
+
+            bool isWatcherCompleted = false;
+            using (var cts = new CancellationTokenSource(timeout))
+            {
                 // Use a semaphore to prevent the [TestMethod] from returning prematurely.
                 using (var semaphore = await RunStaThreadAsync(() =>
                 {
@@ -52,56 +73,6 @@
                 }))
                 {
                     await semaphore.WaitAsync();
-
-                    Assert.IsTrue(watcher.IsClosingRun, "Closing did not run");
-                    Assert.IsFalse(watcher.IsClosedRun, "Closed did run");
-                }
-            }
-        }
-
-        [TestCase]
-        public async Task Verify_Closing_Closed_Operations_Are_Executing_Async()
-        {
-            bool isWatcherCompleted = false;
-            using (var cts = new CancellationTokenSource(5000))
-            {
-                // tested object
-                var watcher = new TestCloseApplicationWatcher(false);
-
-                // Use a semaphore to prevent the [TestMethod] from returning prematurely.
-                using (var semaphore = await RunStaThreadAsync(() =>
-                {
-                    var window = new System.Windows.Window();
-                    
-                    // access handler method
-                    var onWindowClosing = typeof(CloseApplicationWatcherBase).GetMethod("OnWindowClosing", BindingFlags.Static | BindingFlags.NonPublic);
-
-                    Assert.IsNotNull(onWindowClosing);
-
-                    var cancelEventArgs = new CancelEventArgs();
-                    var cancelEventArgsRetry = new CancelEventArgs();
-
-                    window.Closing += (sender, e) =>
-                    {
-                        onWindowClosing.Invoke(watcher, new object[] { window, cancelEventArgsRetry });
-                    };
-
-                    onWindowClosing.Invoke(watcher, new object[] { window, cancelEventArgs });
-
-                    while (!cts.IsCancellationRequested)
-                    {
-                        isWatcherCompleted = watcher.IsClosedRun && watcher.IsClosingRun;
-                        if (isWatcherCompleted)
-                        {
-                            break;
-                        }
-                    }
-                }))
-                {
-                    await semaphore.WaitAsync();
-
-                    Assert.IsTrue(watcher.IsClosingRun, "Closing did not run");
-                    Assert.IsTrue(watcher.IsClosedRun, "Closed did not run");
                 }
             }
         }

--- a/src/Orchestra.Tests/Services/CloseApplicationWatcherBaseFacts.cs
+++ b/src/Orchestra.Tests/Services/CloseApplicationWatcherBaseFacts.cs
@@ -13,12 +13,11 @@
         [TestCase]
         public async Task VerifyClosingClosedOperationsAreExecutingAsync()
         {
-            var tcs = new TaskCompletionSource();
             bool isWatcherCompleted = false;
             using (var cts = new CancellationTokenSource(10000))
             {
                 // tested object
-                var watcher = new TestCloseApplicationWatcher(tcs);
+                var watcher = new TestCloseApplicationWatcher();
 
                 // Use a semaphore to prevent the [TestMethod] from returning prematurely.
                 using (var semaphore = await RunStaThreadAsync(() =>

--- a/src/Orchestra.Tests/Services/CloseApplicationWatcherBaseFacts.cs
+++ b/src/Orchestra.Tests/Services/CloseApplicationWatcherBaseFacts.cs
@@ -1,0 +1,89 @@
+﻿namespace Orchestra.Tests
+{
+    using System;
+    using System.ComponentModel;
+    using System.Reflection;
+    using System.Threading;
+    using System.Threading.Tasks;
+    using NUnit.Framework;
+
+    [TestFixture]
+    internal class CloseApplicationWatcherBaseFacts
+    {
+        [TestCase]
+        public async Task VerifyClosingClosedOperationsAreExecutingAsync()
+        {
+            var tcs = new TaskCompletionSource();
+            bool isWatcherCompleted = false;
+            using (var cts = new CancellationTokenSource(10000))
+            {
+                // tested object
+                var watcher = new TestCloseApplicationWatcher(tcs);
+
+                // Use a semaphore to prevent the [TestMethod] from returning prematurely.
+                using (var semaphore = await RunStaThreadAsync(() =>
+                {
+                    var window = new System.Windows.Window();
+                    
+                    // access handler method
+                    var onWindowClosing = typeof(CloseApplicationWatcherBase).GetMethod("OnWindowClosing", BindingFlags.Static | BindingFlags.NonPublic);
+
+                    Assert.IsNotNull(onWindowClosing);
+
+                    var cancelEventArgs = new CancelEventArgs();
+                    var cancelEventArgsRetry = new CancelEventArgs();
+
+                    window.Closing += (sender, e) =>
+                    {
+                        onWindowClosing.Invoke(watcher, new object[] { window, cancelEventArgsRetry });
+                    };
+
+                    onWindowClosing.Invoke(watcher, new object[] { window, cancelEventArgs });
+
+                    while (!cts.IsCancellationRequested)
+                    {
+                        isWatcherCompleted = watcher.IsClosedRun && watcher.IsClosingRun;
+                        if (isWatcherCompleted)
+                        {
+                            break;
+                        }
+                    }
+                }))
+                {
+                    await semaphore.WaitAsync();
+
+                    Assert.IsTrue(watcher.IsClosedRun);
+                    Assert.IsTrue(watcher.IsClosingRun);
+                }
+            }
+        }
+
+        private async Task<SemaphoreSlim> RunStaThreadAsync(Action action)
+        {
+            var semaphore = new SemaphoreSlim(1);
+            await semaphore.WaitAsync();
+
+            var thread = new Thread(() =>
+            {
+                try
+                {
+                    // Verify new thread able to host UI component
+                    Assert.IsTrue(Thread.CurrentThread.GetApartmentState() == ApartmentState.STA);
+
+                    action();
+
+                    semaphore.Release();
+                }
+                catch (InvalidOperationException)
+                {
+                    // Handle dispatcher access exception happens in test
+                }
+            });
+
+            thread.SetApartmentState(ApartmentState.STA);
+            thread.Start();
+
+            return semaphore;
+        }
+    }
+}

--- a/src/Orchestra.Tests/Services/TestClasses/TestCloseApplicationWatcher.cs
+++ b/src/Orchestra.Tests/Services/TestClasses/TestCloseApplicationWatcher.cs
@@ -4,9 +4,14 @@
 
     internal class TestCloseApplicationWatcher : CloseApplicationWatcherBase
     {
-        public TestCloseApplicationWatcher()
-        {
+        private readonly bool _cancel;
 
+        public TestCloseApplicationWatcher(bool cancel)
+        {
+            _cancel = cancel;
+
+            // Required for unit testing
+            Reset();
         }
 
         public bool IsClosedRun { get; set; }
@@ -21,7 +26,7 @@
         protected override async Task<bool> ClosingAsync()
         {
             IsClosingRun = true;
-            return true;
+            return !_cancel;
         }
     }
 }

--- a/src/Orchestra.Tests/Services/TestClasses/TestCloseApplicationWatcher.cs
+++ b/src/Orchestra.Tests/Services/TestClasses/TestCloseApplicationWatcher.cs
@@ -4,15 +4,9 @@
 
     internal class TestCloseApplicationWatcher : CloseApplicationWatcherBase
     {
-        /// <summary>
-        /// For testing we call watcher in separate thread. As it's used async await inside OnClosingWindowAsync we should
-        /// prevent thread from exit prematurely.
-        /// </summary>
-        private readonly TaskCompletionSource _taskCompletionSource;
-
-        public TestCloseApplicationWatcher(TaskCompletionSource taskCompletionSource)
+        public TestCloseApplicationWatcher()
         {
-            _taskCompletionSource = taskCompletionSource;
+
         }
 
         public bool IsClosedRun { get; set; }
@@ -21,7 +15,6 @@
 
         protected override async Task ClosedAsync()
         {
-            _taskCompletionSource.SetResult();
             IsClosedRun = true;
         }
 

--- a/src/Orchestra.Tests/Services/TestClasses/TestCloseApplicationWatcher.cs
+++ b/src/Orchestra.Tests/Services/TestClasses/TestCloseApplicationWatcher.cs
@@ -1,0 +1,34 @@
+﻿namespace Orchestra.Tests
+{
+    using System.Threading.Tasks;
+
+    internal class TestCloseApplicationWatcher : CloseApplicationWatcherBase
+    {
+        /// <summary>
+        /// For testing we call watcher in separate thread. As it's used async await inside OnClosingWindowAsync we should
+        /// prevent thread from exit prematurely.
+        /// </summary>
+        private readonly TaskCompletionSource _taskCompletionSource;
+
+        public TestCloseApplicationWatcher(TaskCompletionSource taskCompletionSource)
+        {
+            _taskCompletionSource = taskCompletionSource;
+        }
+
+        public bool IsClosedRun { get; set; }
+
+        public bool IsClosingRun { get; set; }
+
+        protected override async Task ClosedAsync()
+        {
+            _taskCompletionSource.SetResult();
+            IsClosedRun = true;
+        }
+
+        protected override async Task<bool> ClosingAsync()
+        {
+            IsClosingRun = true;
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
### Description of Change ###
Reason for changes:
Currently CloseApplicationWatcherBase has two options for adding own action to respond application exit:
- PrepareClosing
- Closing
You can cancel main window Closing event via both methods. Since you don't know for sure what are the watchers registered in the system, you'll force to implement 'undo' in case closing cancellation.
Suggesting add Closed virtual method for actions need to be execute right before closing, when it's known for sure that it is no longer possible to cancel the exit.


### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###
<!-- List all API changes here (or just put None) -->
 
None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- All
- WPF
- UWP
- iOS
- Android

### Behavioral Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
